### PR TITLE
Fix checkboxes in join string

### DIFF
--- a/src/pages/string/join/service.ts
+++ b/src/pages/string/join/service.ts
@@ -5,13 +5,23 @@ export function mergeText(
   joinCharacter: string = ''
 ): string {
   let processedLines: string[] = text.split('\n');
+
   if (deleteTrailingSpaces) {
     processedLines = processedLines.map((line) => line.trimEnd());
   }
 
   if (deleteBlankLines) {
-    processedLines = processedLines.filter((line) => line.trim());
+    processedLines = processedLines.filter((line) => line.trim() !== '');
+  } else {
+    processedLines = processedLines.map((line) =>
+      line.trim() === '' ? line + '\r\n\n' : line
+    );
   }
-
   return processedLines.join(joinCharacter);
 }
+
+// Example text to use
+`This is a line with trailing spaces    
+Another line with trailing spaces   
+   
+Final line without trailing spaces`;


### PR DESCRIPTION
This fix the checkboxes in the string join so when not checked, the delete blank and delete trailing spaces will not delete.  This makes the omni-tools better than https://onlinetexttools.com/join-text#tour since their checkboxes does not work