### PR TITLE
Add text repeat tool

### DIFF
--- a/src/pages/tools/string/index.ts
+++ b/src/pages/tools/string/index.ts
@@ -9,13 +9,15 @@ import { tool as stringToMorse } from './to-morse/meta';
 import { tool as stringSplit } from './split/meta';
 import { tool as stringJoin } from './join/meta';
 import { tool as stringReplace } from './text-replacer/meta';
+import { tool as stringRepeat } from './repeat/meta';
 
 export const stringTools = [
   stringSplit,
   stringJoin,
   stringRemoveDuplicateLines,
   stringToMorse,
-  stringReplace
+  stringReplace,
+  stringRepeat
   // stringReverse,
   // stringRandomizeCase,
   // stringUppercase,

--- a/src/pages/tools/string/repeat/index.tsx
+++ b/src/pages/tools/string/repeat/index.tsx
@@ -1,0 +1,114 @@
+import { Box } from '@mui/material';
+import { useState } from 'react';
+import ToolTextResult from '@components/result/ToolTextResult';
+import { GetGroupsType } from '@components/options/ToolOptions';
+import { repeatText } from './service';
+import TextFieldWithDesc from '@components/options/TextFieldWithDesc';
+import ToolTextInput from '@components/input/ToolTextInput';
+import { initialValues, InitialValuesType } from './initialValues';
+import ToolContent from '@components/ToolContent';
+import { CardExampleType } from '@components/examples/ToolExamples';
+import { ToolComponentProps } from '@tools/defineTool';
+
+const exampleCards: CardExampleType<InitialValuesType>[] = [
+  {
+    title: 'Repeat word five times',
+    description: 'Repeats "Hello!" five times without any delimiter.',
+    sampleText: 'Hello! ',
+    sampleResult: 'Hello! Hello! Hello! Hello! Hello! ',
+    sampleOptions: {
+      textToRepeat: 'Hello! ',
+      repeatAmount: '5',
+      delimiter: ''
+    }
+  },
+  {
+    title: 'Repeat phrase with comma',
+    description:
+      'Repeats "Good job" three times, separated by commas and spaces.',
+    sampleText: 'Good job',
+    sampleResult: 'Good job, Good job, Good job',
+    sampleOptions: {
+      textToRepeat: 'Good job',
+      repeatAmount: '3',
+      delimiter: ', '
+    }
+  },
+  {
+    title: 'Repeat number with space',
+    description: 'Repeats the number "42" four times, separated by spaces.',
+    sampleText: '42',
+    sampleResult: '42 42 42 42',
+    sampleOptions: {
+      textToRepeat: '42',
+      repeatAmount: '4',
+      delimiter: ' '
+    }
+  }
+];
+
+export default function Replacer({ title }: ToolComponentProps) {
+  const [input, setInput] = useState<string>('');
+  const [result, setResult] = useState<string>('');
+
+  function compute(optionsValues: InitialValuesType, input: string) {
+    setResult(repeatText(optionsValues, input));
+  }
+
+  const getGroups: GetGroupsType<InitialValuesType> = ({
+    values,
+    updateField
+  }) => [
+    {
+      title: 'Text Repetitions',
+      component: (
+        <Box>
+          <TextFieldWithDesc
+            description={'Number of repetitions.'}
+            placeholder="Number"
+            value={values.repeatAmount}
+            onOwnChange={(val) => updateField('repeatAmount', val)}
+            type={'number'}
+          />
+        </Box>
+      )
+    },
+    {
+      title: 'Repetitions Delimiter',
+      component: (
+        <Box>
+          <TextFieldWithDesc
+            description={'Delimiter for output copies.'}
+            placeholder="Delimiter"
+            value={values.delimiter}
+            onOwnChange={(val) => updateField('delimiter', val)}
+            type={'text'}
+          />
+        </Box>
+      )
+    }
+  ];
+
+  return (
+    <ToolContent
+      title={title}
+      initialValues={initialValues}
+      getGroups={getGroups}
+      compute={compute}
+      input={input}
+      setInput={setInput}
+      inputComponent={
+        <ToolTextInput title={'Input text'} value={input} onChange={setInput} />
+      }
+      resultComponent={
+        <ToolTextResult title={'Repeated text'} value={result} />
+      }
+      toolInfo={{
+        title: 'Text Replacer',
+        description:
+          'This tool allows you to repeat a given text multiple times with an optional separator.'
+      }}
+      exampleCards={exampleCards}
+    />
+  );
+}

--- a/src/pages/tools/string/repeat/index.tsx
+++ b/src/pages/tools/string/repeat/index.tsx
@@ -104,7 +104,7 @@ export default function Replacer({ title }: ToolComponentProps) {
         <ToolTextResult title={'Repeated text'} value={result} />
       }
       toolInfo={{
-        title: 'Text Replacer',
+        title: 'Repeat text',
         description:
           'This tool allows you to repeat a given text multiple times with an optional separator.'
       }}

--- a/src/pages/tools/string/repeat/initialValues.ts
+++ b/src/pages/tools/string/repeat/initialValues.ts
@@ -1,0 +1,11 @@
+export type InitialValuesType = {
+  textToRepeat: string;
+  repeatAmount: string;
+  delimiter: string;
+};
+
+export const initialValues: InitialValuesType = {
+  textToRepeat: '',
+  repeatAmount: '5',
+  delimiter: ''
+};

--- a/src/pages/tools/string/repeat/meta.ts
+++ b/src/pages/tools/string/repeat/meta.ts
@@ -1,0 +1,13 @@
+import { defineTool } from '@tools/defineTool';
+import { lazy } from 'react';
+
+export const tool = defineTool('string', {
+  name: 'Repeat text',
+  path: 'repeat',
+  shortDescription: 'Repeat text multiple times.',
+  icon: 'material-symbols-light:replay',
+  description:
+    'This tool allows you to repeat a given text multiple times with an optional separator.',
+  keywords: ['text', 'repeat'],
+  component: lazy(() => import('./index'))
+});

--- a/src/pages/tools/string/repeat/meta.ts
+++ b/src/pages/tools/string/repeat/meta.ts
@@ -4,7 +4,7 @@ import { lazy } from 'react';
 export const tool = defineTool('string', {
   name: 'Repeat text',
   path: 'repeat',
-  shortDescription: 'Repeat text multiple times.',
+  shortDescription: 'Repeat text multiple times',
   icon: 'material-symbols-light:replay',
   description:
     'This tool allows you to repeat a given text multiple times with an optional separator.',

--- a/src/pages/tools/string/repeat/repeatText.service.test.ts
+++ b/src/pages/tools/string/repeat/repeatText.service.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+import { repeatText } from './service';
+import { initialValues } from './initialValues';
+
+describe('repeatText function', () => {
+  it('should repeat the letter correctly', () => {
+    const text = 'i';
+    const repeatAmount = '5';
+    const result = repeatText({ ...initialValues, repeatAmount }, text);
+    expect(result).toBe('iiiii');
+  });
+
+  it('should repeat the word correctly', () => {
+    const text = 'hello';
+    const repeatAmount = '3';
+    const result = repeatText({ ...initialValues, repeatAmount }, text);
+    expect(result).toBe('hellohellohello');
+  });
+
+  it('should repeat the word with a space delimiter correctly', () => {
+    const text = 'word';
+    const repeatAmount = '3';
+    const delimiter = ' ';
+    const result = repeatText(
+      { ...initialValues, repeatAmount, delimiter },
+      text
+    );
+    expect(result).toBe('word word word');
+  });
+
+  it('should repeat the word with a space and a comma delimiter correctly', () => {
+    const text = 'test';
+    const repeatAmount = '3';
+    const delimiter = ', ';
+    const result = repeatText(
+      { ...initialValues, repeatAmount, delimiter },
+      text
+    );
+    expect(result).toBe('test, test, test');
+  });
+
+  it('Should not repeat text if repeatAmount is zero', () => {
+    const text = 'something';
+    const repeatAmount = '0';
+    const result = repeatText({ ...initialValues, repeatAmount }, text);
+    expect(result).toBe('');
+  });
+
+  it('Should not repeat text if repeatAmount is not entered', () => {
+    const text = 'something';
+    const repeatAmount = '';
+    const result = repeatText({ ...initialValues, repeatAmount }, text);
+    expect(result).toBe('');
+  });
+});

--- a/src/pages/tools/string/repeat/service.ts
+++ b/src/pages/tools/string/repeat/service.ts
@@ -1,0 +1,9 @@
+import { InitialValuesType } from './initialValues';
+
+export function repeatText(options: InitialValuesType, text: string) {
+  const { repeatAmount, delimiter } = options;
+
+  const parsedAmount = parseInt(repeatAmount) || 0;
+
+  return Array(parsedAmount).fill(text).join(delimiter);
+}


### PR DESCRIPTION
Implemented a text repeat tool that allows users to repeat input text multiple times with optional custom delimiters.

- Created `Repeat` component with input fields for text, repetition amount, and delimiter. 
- Added `repeatText` function to handle text repetition.  
- Supported custom repetition amounts and delimiters.  
- Included tests to ensure correct functionality.