### PR TITLE
Fix Error: ENOENT: no such file or directory when creating tool

### DIFF
--- a/scripts/create-tool.mjs
+++ b/scripts/create-tool.mjs
@@ -54,7 +54,7 @@ function createFolderStructure(basePath, foldersToCreateIndexCount) {
   }
 
   // Start the recursive folder creation
-  recursiveCreate('.', 0);
+  recursiveCreate('/', 0);
 }
 
 const toolNameCamelCase = toolName.replace(/-./g, (x) => x[1].toUpperCase());


### PR DESCRIPTION
This may be user error, but when I try to create a new tool on Ubuntu, I get:

```
npm run script:create:tool generic-calc /number/calculators

> omni-tools@0.1.0 script:create:tool
> node scripts/create-tool.mjs generic-calc /number/calculators

File created: home/daniel/Projects/omni-tools/src/pages/tools/index.ts
Directory created: /home/daniel/Projects/omni-tools/src/pages/tools/number/calculators/generic-calc
node:internal/fs/promises:638
  return new FileHandle(await PromisePrototypeThen(
                        ^

Error: ENOENT: no such file or directory, open '/home/daniel/Projects/omni-tools/src/pages/tools/number/calculators/generic-calc/index.tsx'
    at async open (node:internal/fs/promises:638:25)
    at async writeFile (node:internal/fs/promises:1221:14)
    at async createToolFile (file:///home/daniel/Projects/omni-tools/scripts/create-tool.mjs:70:3) {
  errno: -2,
  code: 'ENOENT',
  syscall: 'open',
  path: '/home/daniel/Projects/omni-tools/src/pages/tools/number/calculators/generic-calc/index.tsx'
}

```
But the issue seems to go away with this one char fix, although I don't if there's some issue on Mac or Windows.