### PR TITLE
[bugfix/logo-right-click] : Omnitools logo to allow link if right cli…

### DIFF
--- a/src/components/Navbar/index.tsx
+++ b/src/components/Navbar/index.tsx
@@ -100,12 +100,13 @@ const Navbar: React.FC<NavbarProps> = ({ onSwitchTheme }) => {
           alignItems: 'center'
         }}
       >
-        <img
-          onClick={() => navigate('/')}
-          style={{ cursor: 'pointer' }}
-          src={logo}
-          width={isMobile ? '80px' : '150px'}
-        />
+        <Link to="/">
+          <img
+            style={{ cursor: 'pointer' }}
+            src={logo}
+            width={isMobile ? '80px' : '150px'}
+          />
+        </Link>
         {isMobile ? (
           <>
             <IconButton


### PR DESCRIPTION

# ISSUE :

Clicking the Omni-tools logo (top-left corner) navigates to the homepage.
However, right-clicking the logo only gives an option to open the image itself in a new window, not the homepage.

# FIX :

- Wrap the img tag within "Link" component from react-router
- map "to" prop of "Link" component to "/" or home
- Remove onClick handler from the img tag

<img width="562" alt="image" src="https://github.com/user-attachments/assets/0ccebf6a-0b2d-40ac-a5fb-d3b0d84fdda3" />


Fixes https://github.com/iib0011/omni-tools/issues/123.