### PR TITLE
Patch nginx config in Docker image to fix SPA routing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ RUN npm run build
 FROM nginx:alpine
 
 COPY --from=build /app/dist /usr/share/nginx/html
+RUN sed -i 's|index  index.html index.htm;|index  index.html index.htm;\n        try_files $uri $uri/ /index.html;|' /etc/nginx/conf.d/default.conf
 
 # Expose port 80
 EXPOSE 80


### PR DESCRIPTION
Prevents nginx from returning 404 errors when navigating directly to a non-root path