### PR TITLE
feat(docker): update the ci workflow to also push to ghcr.io

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,12 @@ on:
   pull_request:
     branches:
       - main
+      
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+
 jobs:
   test-and-build:
     runs-on: ubuntu-latest
@@ -65,11 +71,19 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Log in to the Github Container registry
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Extract metadata for Docker
         id: meta
         uses: docker/metadata-action@v4
         with:
-          images: iib0011/omni-tools
+          images: |
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+            iib0011/omni-tools
           tags: |
             type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
             type=semver,pattern={{version}},enable=${{ startsWith(github.ref, 'refs/tags/v') }}

--- a/README.md
+++ b/README.md
@@ -90,6 +90,10 @@ Stay tuned as we continue to expand and improve our collection!
 
 ## Self-host/Run
 
+> [!TIP]
+> You can use either the DockerHub Image `iib0011/omni-tools` <br />
+> or use the GitHub Container Registry `ghcr.io/iib0011/omni-tools`
+
 ### Docker
 
 ```bash


### PR DESCRIPTION
This pull request updates the CI workflow to support publishing Docker images to the GitHub Container Registry (GHCR) in addition to DockerHub. It also updates the `README.md` to inform users about the new GHCR image option.

See #179 for more informations


### CI Workflow Updates:

* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR11-R16): Added environment variables `REGISTRY` and `IMAGE_NAME` to define the container registry and image name dynamically.
* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR74-R86): Added a step to log in to the GitHub Container Registry using the `docker/login-action` and updated the `docker/metadata-action` to include the GHCR image alongside the DockerHub image.

### Documentation Update:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R93-R96): Added a tip to inform users that they can now use the Docker image from either DockerHub (`iib0011/omni-tools`) or the GitHub Container Registry (`ghcr.io/iib0011/omni-tools`).