### PR TITLE
Create a release with tar file on CI and upload artifact

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,6 +105,11 @@ jobs:
       - name: Create archives
         run: |
           tar -cvzf release.tar.gz -C dist $(ls dist)
+      - uses: actions/upload-artifact@v4
+        with:
+          name: release.tar.gz
+          path: release.tar.gz
+          retention-days: 30
       - name: Upload Binaries to Release
         if: startsWith(github.ref, 'refs/tags/v')
         uses: svenstaro/upload-release-action@v2


### PR DESCRIPTION
This closes #194.

I've added a new step on the cy.yml file to create an artifact on every commit on main and to create a release on GitHub on every tagged push with attached the compiled fronted.

See it on my fork: 

- [Release](https://github.com/timendum/omni-tools/releases)
- [Artifact](https://github.com/timendum/omni-tools/actions/runs/16340229879)