### PR TITLE
fix(ui): improve code editor styling to match MUI components

### DIFF
--- a/src/components/input/ToolCodeInput.tsx
+++ b/src/components/input/ToolCodeInput.tsx
@@ -5,7 +5,10 @@ import InputHeader from '../InputHeader';
 import InputFooter from './InputFooter';
 import { useTranslation } from 'react-i18next';
 import Editor from '@monaco-editor/react';
-import { globalInputHeight } from '../../config/uiConfig';
+import {
+  globalInputHeight,
+  codeInputHeightOffset
+} from '../../config/uiConfig';
 
 export default function ToolCodeInput({
   value,
@@ -53,14 +56,58 @@ export default function ToolCodeInput({
   return (
     <Box>
       <InputHeader title={title || t('toolTextInput.input')} />
-      <Box height={globalInputHeight}>
-        <Editor
-          height={'87%'}
-          language={language}
-          theme={theme.palette.mode === 'dark' ? 'vs-dark' : 'light'}
-          value={value}
-          onChange={(value) => onChange(value ?? '')}
-        />
+      <Box
+        height={`${globalInputHeight + codeInputHeightOffset}px`} // The +codeInputHeightOffset compensates for internal padding/border differences between Monaco Editor and MUI TextField
+        sx={{
+          display: 'flex',
+          flexDirection: 'column'
+        }}
+      >
+        <Box
+          sx={(theme) => ({
+            height: '100%',
+            display: 'flex',
+            flexDirection: 'column',
+            backgroundColor: 'background.paper',
+            '.monaco-editor': {
+              height: '100% !important',
+              outline: 'none !important',
+              '.overflow-guard': {
+                height: '100% !important',
+                border:
+                  theme.palette.mode === 'light'
+                    ? '1px solid rgba(0, 0, 0, 0.23)'
+                    : '1px solid rgba(255, 255, 255, 0.23)',
+                borderRadius: 1,
+                transition: theme.transitions.create(
+                  ['border-color', 'background-color'],
+                  {
+                    duration: theme.transitions.duration.shorter
+                  }
+                )
+              },
+              '&:hover .overflow-guard': {
+                borderColor: theme.palette.text.primary
+              }
+            },
+            '.decorationsOverviewRuler': {
+              display: 'none !important'
+            }
+          })}
+        >
+          <Editor
+            height="100%"
+            language={language}
+            theme={theme.palette.mode === 'dark' ? 'vs-dark' : 'light'}
+            value={value}
+            onChange={(value) => onChange(value ?? '')}
+            options={{
+              overviewRuler: {
+                enabled: false
+              }
+            }}
+          />
+        </Box>
         <InputFooter handleCopy={handleCopy} handleImport={handleImportClick} />
         <input
           type="file"

--- a/src/components/input/ToolCodeInput.tsx
+++ b/src/components/input/ToolCodeInput.tsx
@@ -102,8 +102,12 @@ export default function ToolCodeInput({
             value={value}
             onChange={(value) => onChange(value ?? '')}
             options={{
-              overviewRuler: {
-                enabled: false
+              scrollbar: {
+                vertical: 'visible',
+                horizontal: 'visible',
+                verticalScrollbarSize: 10,
+                horizontalScrollbarSize: 10,
+                alwaysConsumeMouseWheel: false
               }
             }}
           />

--- a/src/config/uiConfig.ts
+++ b/src/config/uiConfig.ts
@@ -1,4 +1,5 @@
 export const globalInputHeight = 300;
+export const codeInputHeightOffset = 7; // Offset to visually match Monaco and MUI TextField heights
 export const globalDescriptionFontSize = 12;
 export const categoriesColors: string[] = [
   '#8FBC5D',


### PR DESCRIPTION
# Enhanced Code Editor Styling

This PR improves the visual consistency between the Monaco Editor and Material-UI components in our application.

## Changes

- Added proper border styling to match MUI TextField components
- Implemented hover state effects with smooth transitions
- Fixed height calculations by introducing `codeInputHeightOffset` constant
- Removed unnecessary overview ruler for a cleaner interface
- Ensured consistent height rendering across different themes

## Visual Improvements

- The editor now has the same border style as other MUI inputs
- Border color changes on hover to match MUI behavior
- Proper height alignment with other input components
- Consistent appearance in both light and dark themes

## Technical Details

- Introduced `codeInputHeightOffset` (7px) in `uiConfig.ts` to compensate for internal padding differences
- Added theme-aware styling using MUI's theme system
- Implemented proper CSS transitions for hover effects
- Enhanced component structure for better height management

## Testing Notes

Please verify the following:
- Editor appearance matches other MUI inputs
- Smooth hover transitions
- Correct height alignment with adjacent components
- Proper appearance in both light and dark themes