### PR TITLE
fix(create-tool): generate toolDir relative to cwd

### DIFF
--- a/scripts/create-tool.mjs
+++ b/scripts/create-tool.mjs
@@ -1,6 +1,6 @@
 import { readFile, writeFile } from 'fs/promises';
 import fs from 'fs';
-import { dirname, join, sep } from 'path';
+import { dirname, join, relative, sep } from 'path';
 import { fileURLToPath } from 'url';
 
 const currentDirname = dirname(fileURLToPath(import.meta.url));
@@ -62,7 +62,7 @@ const toolNameTitleCase =
   toolName[0].toUpperCase() + toolName.slice(1).replace(/-/g, ' ');
 const toolDir = join(toolsDir, toolName);
 const type = folder.split(sep)[folder.split(sep).length - 1];
-await createFolderStructure(toolDir, folder.split(sep).length);
+await createFolderStructure(relative('.', toolDir), folder.split(sep).length);
 console.log(`Directory created: ${toolDir}`);
 
 const createToolFile = async (name, content) => {


### PR DESCRIPTION
Fixes #235
The issue stems from the createFolderStructure function using recursiveCreate('.', 0), which causes all folder paths to be resolved relative to process.cwd().

As a result, calling .split(sep) on an absolute path and feeding it to recursiveCreate('.', ...) leads to the full absolute path being recreated inside the current directory, e.g.:

`$PWD/home/user/...`

Suggested Fix
Before passing toolDir to createFolderStructure(...), normalize it to be relative to the current working directory, e.g.:
```
import { relative } from 'path';

createFolderStructure(relative('.', toolDir), folder.split(sep).length);
```
This allows the function to create directories in the correct location relative to the actual working directory.
