### PR TITLE
feat(docker): added DEFAULT_LANG environment variable for default language (#251)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,8 @@ RUN npm run build
 
 FROM nginx:alpine
 
+ENV DEFAULT_LANG=en
+
 COPY --from=build /app/dist /usr/share/nginx/html
 
 RUN sed -i 's/application\/javascript.*js;/application\/javascript                js mjs;/' /etc/nginx/mime.types


### PR DESCRIPTION
Description:
Adds a Docker environment variable DEFAULT_LANG to set the app’s default language. Users can override it at runtime (e.g., -e DEFAULT_LANG=fr) to avoid selecting their preferred language every time.
