### PR TITLE
Changed the 'type' for WPA/WPA2/WPA3 to just 'WPA'

### DIFF
--- a/src/pages/tools/image/generic/qr-code/index.tsx
+++ b/src/pages/tools/image/generic/qr-code/index.tsx
@@ -40,7 +40,7 @@ const initialValues: InitialValuesType = {
   // WiFi
   wifiSsid: '',
   wifiPassword: '',
-  wifiEncryption: 'WPA/WPA2',
+  wifiEncryption: 'WPA',
 
   // vCard
   vCardName: '',
@@ -353,7 +353,7 @@ export default function QRCodeGenerator({ title }: ToolComponentProps) {
                   label="Encryption Type"
                   margin="normal"
                 >
-                  <MenuItem value="WPA/WPA2">WPA/WPA2</MenuItem>
+                  <MenuItem value="WPA">WPA</MenuItem>
                   <MenuItem value="WEP">WEP</MenuItem>
                   <MenuItem value="None">None</MenuItem>
                 </TextField>

--- a/src/pages/tools/image/generic/qr-code/types.ts
+++ b/src/pages/tools/image/generic/qr-code/types.ts
@@ -7,7 +7,7 @@ export type QRCodeType =
   | 'WiFi'
   | 'vCard';
 
-export type WifiEncryptionType = 'WPA/WPA2' | 'WEP' | 'None';
+export type WifiEncryptionType = 'WPA' | 'WEP' | 'None';
 
 export interface InitialValuesType {
   qrCodeType: QRCodeType;


### PR DESCRIPTION
The URI wifi "type" for all variations of WPA is simply "WPA". This updates the value in the qr code tool option from "WPA/WPA2" to "WPA". The tool should now work with WPA2/WPA3, WPA3, etc.