### PR TITLE
feat: Add Meme Generator tool with text customization options

### DIFF
--- a/public/locales/en/image.json
+++ b/public/locales/en/image.json
@@ -101,5 +101,28 @@
     "description": "Rotate an image by a specified angle.",
     "shortDescription": "Rotate an image easily.",
     "title": "Rotate Image"
+  },
+  "memeGenerator": {
+    "title": "Meme Generator",
+    "description": "Create custom memes by adding text to images.",
+    "shortDescription": "Add text to images to create memes.",
+    "inputTitle": "Upload Image",
+    "resultTitle": "Generated Meme",
+    "textOptions": "Text Options",
+    "topText": "Top Text",
+    "topTextDescription": "Text to appear at the top of the image",
+    "bottomText": "Bottom Text",
+    "bottomTextDescription": "Text to appear at the bottom of the image",
+    "styleOptions": "Style Options",
+    "fontSize": "Font Size",
+    "fontSizeDescription": "Size of the text relative to image height",
+    "textColor": "Text Color",
+    "textColorDescription": "Color of the text",
+    "strokeColor": "Stroke Color",
+    "strokeColorDescription": "Color of the text outline",
+    "toolInfo": {
+      "title": "Meme Generator",
+      "description": "Upload an image and add top and bottom text to create a meme. You can customize the font size and colors."
+    }
   }
 }

--- a/src/pages/tools/image/generic/index.ts
+++ b/src/pages/tools/image/generic/index.ts
@@ -10,6 +10,7 @@ import { tool as qrCodeGenerator } from './qr-code/meta';
 import { tool as rotateImage } from './rotate/meta';
 import { tool as convertToJpg } from './convert-to-jpg/meta';
 import { tool as imageEditor } from './editor/meta';
+import { tool as memeGenerator } from './meme-generator/meta';
 export const imageGenericTools = [
   imageEditor,
   resizeImage,
@@ -22,5 +23,6 @@ export const imageGenericTools = [
   imageToText,
   qrCodeGenerator,
   rotateImage,
-  convertToJpg
+  convertToJpg,
+  memeGenerator
 ];

--- a/src/pages/tools/image/generic/meme-generator/index.tsx
+++ b/src/pages/tools/image/generic/meme-generator/index.tsx
@@ -1,0 +1,125 @@
+import { Box } from '@mui/material';
+import React, { useState } from 'react';
+import ToolImageInput from '@components/input/ToolImageInput';
+import ToolFileResult from '@components/result/ToolFileResult';
+import { GetGroupsType } from '@components/options/ToolOptions';
+import TextFieldWithDesc from '@components/options/TextFieldWithDesc';
+import ToolContent from '@components/ToolContent';
+import { ToolComponentProps } from '@tools/defineTool';
+import ColorSelector from '@components/options/ColorSelector';
+import { generateMeme } from './service';
+import { InitialValuesType } from './types';
+import { useTranslation } from 'react-i18next';
+
+const initialValues: InitialValuesType = {
+  topText: '',
+  bottomText: '',
+  fontSize: 10,
+  textColor: '#FFFFFF',
+  strokeColor: '#000000'
+};
+
+export default function MemeGenerator({ title }: ToolComponentProps) {
+  const { t } = useTranslation('image');
+  const [input, setInput] = useState<File | null>(null);
+  const [result, setResult] = useState<File | null>(null);
+
+  const compute = async (optionsValues: InitialValuesType, input: any) => {
+    if (!input) return;
+    setResult(await generateMeme(input, optionsValues));
+  };
+
+  const getGroups: GetGroupsType<InitialValuesType> = ({
+    values,
+    updateField
+  }) => [
+    {
+      title: t('memeGenerator.textOptions'),
+      component: (
+        <Box>
+          <TextFieldWithDesc
+            value={values.topText}
+            onOwnChange={(val) => updateField('topText', val)}
+            description={t('memeGenerator.topTextDescription')}
+            label={t('memeGenerator.topText')}
+            fullWidth
+            margin="normal"
+          />
+          <TextFieldWithDesc
+            value={values.bottomText}
+            onOwnChange={(val) => updateField('bottomText', val)}
+            description={t('memeGenerator.bottomTextDescription')}
+            label={t('memeGenerator.bottomText')}
+            fullWidth
+            margin="normal"
+          />
+        </Box>
+      )
+    },
+    {
+      title: t('memeGenerator.styleOptions'),
+      component: (
+        <Box>
+          <TextFieldWithDesc
+            value={String(values.fontSize)}
+            onOwnChange={(val) => updateField('fontSize', Number(val))}
+            description={t('memeGenerator.fontSizeDescription')}
+            label={t('memeGenerator.fontSize')}
+            inputProps={{
+              type: 'number',
+              min: 1,
+              max: 50
+            }}
+            fullWidth
+            margin="normal"
+          />
+          <ColorSelector
+            value={values.textColor}
+            onColorChange={(val) => updateField('textColor', val)}
+            label={t('memeGenerator.textColor')}
+            description={t('memeGenerator.textColorDescription')}
+            fullWidth
+            margin="normal"
+          />
+          <ColorSelector
+            value={values.strokeColor}
+            onColorChange={(val) => updateField('strokeColor', val)}
+            label={t('memeGenerator.strokeColor')}
+            description={t('memeGenerator.strokeColorDescription')}
+            fullWidth
+            margin="normal"
+          />
+        </Box>
+      )
+    }
+  ];
+
+  return (
+    <ToolContent
+      title={title}
+      initialValues={initialValues}
+      getGroups={getGroups}
+      compute={compute}
+      input={input}
+      inputComponent={
+        <ToolImageInput
+          value={input}
+          onChange={setInput}
+          accept={['image/jpeg', 'image/png', 'image/svg+xml', 'image/gif']}
+          title={t('memeGenerator.inputTitle')}
+        />
+      }
+      resultComponent={
+        <ToolFileResult
+          title={t('memeGenerator.resultTitle')}
+          value={result}
+          extension={input?.name.split('.').pop() || 'png'}
+        />
+      }
+      toolInfo={{
+        title: t('memeGenerator.toolInfo.title'),
+        description: t('memeGenerator.toolInfo.description')
+      }}
+    />
+  );
+}

--- a/src/pages/tools/image/generic/meme-generator/meta.ts
+++ b/src/pages/tools/image/generic/meme-generator/meta.ts
@@ -1,0 +1,15 @@
+import { defineTool } from '@tools/defineTool';
+import { lazy } from 'react';
+
+export const tool = defineTool('image-generic', {
+  path: 'meme-generator',
+  icon: 'mdi:emoticon-lol-outline',
+  keywords: ['meme', 'generator', 'creator', 'image', 'text'],
+  component: lazy(() => import('./index')),
+  i18n: {
+    name: 'image:memeGenerator.title',
+    description: 'image:memeGenerator.description',
+    shortDescription: 'image:memeGenerator.shortDescription',
+    userTypes: ['generalUsers']
+  }
+});

--- a/src/pages/tools/image/generic/meme-generator/service.ts
+++ b/src/pages/tools/image/generic/meme-generator/service.ts
@@ -1,0 +1,74 @@
+import { InitialValuesType } from './types';
+
+export const generateMeme = async (
+  imageFile: File,
+  options: InitialValuesType
+): Promise<File> => {
+  return new Promise((resolve, reject) => {
+    const img = new Image();
+    img.onload = () => {
+      const canvas = document.createElement('canvas');
+      canvas.width = img.width;
+      canvas.height = img.height;
+      const ctx = canvas.getContext('2d');
+      if (!ctx) {
+        reject(new Error('Could not get canvas context'));
+        return;
+      }
+
+      // Draw image
+      ctx.drawImage(img, 0, 0);
+
+      // Configure text style
+      const fontSize = (options.fontSize / 100) * img.height; // Scale font size relative to image height
+      ctx.font = `bold ${fontSize}px Impact, sans-serif`;
+      ctx.fillStyle = options.textColor;
+      ctx.strokeStyle = options.strokeColor;
+      ctx.lineWidth = fontSize / 15;
+      ctx.textAlign = 'center';
+
+      // Draw Top Text
+      if (options.topText) {
+        ctx.textBaseline = 'top';
+        ctx.strokeText(
+          options.topText.toUpperCase(),
+          canvas.width / 2,
+          fontSize * 0.2
+        );
+        ctx.fillText(
+          options.topText.toUpperCase(),
+          canvas.width / 2,
+          fontSize * 0.2
+        );
+      }
+
+      // Draw Bottom Text
+      if (options.bottomText) {
+        ctx.textBaseline = 'bottom';
+        ctx.strokeText(
+          options.bottomText.toUpperCase(),
+          canvas.width / 2,
+          canvas.height - fontSize * 0.2
+        );
+        ctx.fillText(
+          options.bottomText.toUpperCase(),
+          canvas.width / 2,
+          canvas.height - fontSize * 0.2
+        );
+      }
+
+      canvas.toBlob((blob) => {
+        if (blob) {
+          const newFile = new File([blob], `meme-${imageFile.name}`, {
+            type: imageFile.type
+          });
+          resolve(newFile);
+        } else {
+          reject(new Error('Canvas to Blob failed'));
+        }
+      }, imageFile.type);
+    };
+    img.onerror = reject;
+    img.src = URL.createObjectURL(imageFile);
+  });
+};

--- a/src/pages/tools/image/generic/meme-generator/types.ts
+++ b/src/pages/tools/image/generic/meme-generator/types.ts
@@ -1,0 +1,7 @@
+export type InitialValuesType = {
+  topText: string;
+  bottomText: string;
+  fontSize: number;
+  textColor: string;
+  strokeColor: string;
+};


### PR DESCRIPTION
- fixes #271
<img width="1740" height="879" alt="image" src="https://github.com/user-attachments/assets/e02ae836-84a8-48df-ae44-ae40bb2595f5" />

- currently you can only add text on the top and bottom of the image provided by the user, can update later to add text on a selected coordinate on the image