### PR TITLE
Add remove file option to JPG → PNG tool

### DIFF
--- a/src/components/common/RemoveFileButton.tsx
+++ b/src/components/common/RemoveFileButton.tsx
@@ -1,0 +1,19 @@
+import { Button } from '@mui/material';
+
+interface RemoveFileButtonProps {
+  onRemove: () => void;
+}
+
+export default function RemoveFileButton({ onRemove }: RemoveFileButtonProps) {
+  return (
+    <Button
+      variant="outlined"
+      color="error"
+      size="small"
+      onClick={onRemove}
+      sx={{ mt: 1 }}
+    >
+      Remove File
+    </Button>
+  );
+}

--- a/src/pages/tools/image/png/convert-jgp-to-png/index.tsx
+++ b/src/pages/tools/image/png/convert-jgp-to-png/index.tsx
@@ -23,6 +23,11 @@ export default function ConvertJgpToPng({ title }: ToolComponentProps) {
   const [input, setInput] = useState<File | null>(null);
   const [result, setResult] = useState<File | null>(null);
 
+  const handleRemove = () => {
+    setInput(null);
+    setResult(null);
+  };
+
   const compute = async (
     optionsValues: typeof initialValues,
     input: any
@@ -101,12 +106,34 @@ export default function ConvertJgpToPng({ title }: ToolComponentProps) {
       title={title}
       input={input}
       inputComponent={
-        <ToolImageInput
-          value={input}
-          onChange={setInput}
-          accept={['image/jpeg']}
-          title={'Input JPG'}
-        />
+        <Box>
+          <ToolImageInput
+            value={input}
+            onChange={(file) => {
+              setInput(file);
+              setResult(null);
+            }}
+            accept={['image/jpeg']}
+            title={'Input JPG'}
+          />
+          {input && (
+            <Box mt={1}>
+              <button
+                onClick={handleRemove}
+                style={{
+                  padding: '6px 10px',
+                  borderRadius: 6,
+                  border: '1px solid #e57373',
+                  background: 'transparent',
+                  color: '#e57373',
+                  cursor: 'pointer'
+                }}
+              >
+                Remove file
+              </button>
+            </Box>
+          )}
+        </Box>
       }
       resultComponent={
         <ToolFileResult title={'Output PNG'} value={result} extension={'png'} />

--- a/src/utils/resetFileState.ts
+++ b/src/utils/resetFileState.ts
@@ -1,0 +1,9 @@
+export function resetFileState<T>(
+  setFile: (value: T | null) => void,
+  setResult?: (value: any) => void
+) {
+  setFile(null);
+  if (setResult) {
+    setResult(null);
+  }
+}


### PR DESCRIPTION
This PR adds a remove/reset option to the JPG → PNG converter.

Changes:
- Added a "Remove file" button when an image is uploaded
- Clears both the input file and generated result on removal
- Ensures the result resets when a new file is selected

This improves usability by allowing users to upload a new file without refreshing the page.

If useful, I can extend this reset behavior to other file-upload tools as well.