### PR TITLE
fix(docker): explicitly enable IPv6 in nginx config (#264)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,11 @@ RUN sed -i 's/application\/javascript.*js;/application\/javascript              
 
 RUN sed -i 's|index  index.html index.htm;|index  index.html index.htm;\n        try_files $uri $uri/ /index.html;|' /etc/nginx/conf.d/default.conf
 
+# Explicitly add IPv6 listen directive since the nginx entrypoint script
+# (10-listen-on-ipv6-by-default.sh) skips IPv6 configuration when it detects
+# that default.conf has already been modified (see issue #264).
+RUN sed -i 's|listen       80;|listen       80;\n    listen  [::]:80;|' /etc/nginx/conf.d/default.conf
+
 EXPOSE 80
 
 CMD ["nginx", "-g", "daemon off;"]


### PR DESCRIPTION
## Summary

Fixes #264

## Problem

The `nginx:alpine` image ships with a startup script (`10-listen-on-ipv6-by-default.sh`) that automatically adds `listen [::]:80;` to `/etc/nginx/conf.d/default.conf` — **but only if the file hasn't been modified**. Since the Dockerfile already patches `default.conf` via `sed` (to add `try_files`), the script detects the change and skips IPv6 configuration. As a result, the container only listens on IPv4.

## Fix

Add an explicit `listen [::]:80;` directive via a separate `RUN sed` command, mirroring exactly what the entrypoint script would have done.

```diff
+ RUN sed -i 's|listen       80;|listen       80;\n    listen  [::]:80;|' /etc/nginx/conf.d/default.conf
```

## Testing

Verified the resulting `default.conf` contains both `listen 80;` and `listen [::]:80;` after the build stage. No functional changes to routing or static file serving.