### PR TITLE
Fix absolute path handling in create-tool.mjs

### DIFF
--- a/scripts/create-tool.mjs
+++ b/scripts/create-tool.mjs
@@ -1,31 +1,20 @@
 import { readFile, writeFile } from 'fs/promises';
 import fs from 'fs';
-import { dirname, join, sep } from 'path';
+import { dirname, join, parse, relative, resolve, sep } from 'path';
 import { fileURLToPath } from 'url';
 
 const currentDirname = dirname(fileURLToPath(import.meta.url));
 
-const toolName = process.argv[2];
-const folder = process.argv[3];
-
-const toolsDir = join(
-  currentDirname,
-  '..',
-  'src',
-  'pages',
-  'tools',
-  folder ?? ''
-);
-if (!toolName) {
-  throw new Error('Please specify a toolname.');
-}
-
-function capitalizeFirstLetter(string) {
+export function capitalizeFirstLetter(string) {
   return string.charAt(0).toUpperCase() + string.slice(1);
 }
 
-function createFolderStructure(basePath, foldersToCreateIndexCount) {
-  const folderArray = basePath.split(sep);
+export function createFolderStructure(basePath, foldersToCreateIndexCount) {
+  const absoluteBasePath = resolve(basePath);
+  const { root } = parse(absoluteBasePath);
+  const folderArray = relative(root, absoluteBasePath)
+    .split(sep)
+    .filter(Boolean);
 
   function recursiveCreate(currentBase, index) {
     if (index >= folderArray.length) {
@@ -54,26 +43,40 @@ function createFolderStructure(basePath, foldersToCreateIndexCount) {
   }
 
   // Start the recursive folder creation
-  recursiveCreate('.', 0);
+  recursiveCreate(root || '.', 0);
 }
 
-const toolNameCamelCase = toolName.replace(/-./g, (x) => x[1].toUpperCase());
-const toolNameTitleCase =
-  toolName[0].toUpperCase() + toolName.slice(1).replace(/-/g, ' ');
-const toolDir = join(toolsDir, toolName);
-const type = folder.split(sep)[folder.split(sep).length - 1];
-await createFolderStructure(toolDir, folder.split(sep).length);
-console.log(`Directory created: ${toolDir}`);
+export async function main(args = process.argv.slice(2)) {
+  const [toolName, folder] = args;
 
-const createToolFile = async (name, content) => {
-  const filePath = join(toolDir, name);
-  await writeFile(filePath, content.trim());
-  console.log(`File created: ${filePath}`);
-};
+  if (!toolName) {
+    throw new Error('Please specify a toolname.');
+  }
 
-createToolFile(
-  `index.tsx`,
-  `
+  if (!folder) {
+    throw new Error('Please specify a folder.');
+  }
+
+  const toolsDir = join(currentDirname, '..', 'src', 'pages', 'tools', folder);
+  const toolNameCamelCase = toolName.replace(/-./g, (x) => x[1].toUpperCase());
+  const toolNameTitleCase =
+    toolName[0].toUpperCase() + toolName.slice(1).replace(/-/g, ' ');
+  const toolDir = join(toolsDir, toolName);
+  const folderParts = folder.split(sep).filter(Boolean);
+  const type = folderParts[folderParts.length - 1];
+
+  createFolderStructure(toolDir, folderParts.length);
+  console.log(`Directory created: ${toolDir}`);
+
+  const createToolFile = async (name, content) => {
+    const filePath = join(toolDir, name);
+    await writeFile(filePath, content.trim());
+    console.log(`File created: ${filePath}`);
+  };
+
+  await createToolFile(
+    `index.tsx`,
+    `
 import { Box } from '@mui/material';
 import React, { useState } from 'react';
 import ToolContent from '@components/ToolContent';
@@ -137,44 +140,45 @@ export default function ${capitalizeFirstLetter(toolNameCamelCase)}({
   );
 }
 `
-);
-const validNamespaces = [
-  'string',
-  'number',
-  'video',
-  'list',
-  'json',
-  'time',
-  'csv',
-  'pdf',
-  'audio',
-  'xml',
-  'translation',
-  'image'
-];
-const isValidI18nNamespace = (value) => {
-  return validNamespaces.includes(value);
-};
+  );
 
-const getI18nNamespaceFromToolCategory = (category) => {
-  // Map image-related categories to 'image'
-  if (['png', 'image-generic'].includes(category)) {
-    return 'image';
-  } else if (['gif'].includes(category)) {
-    return 'video';
-  }
-  // Use type guard to check if category is a valid I18nNamespaces
-  if (isValidI18nNamespace(category)) {
-    return category;
-  }
+  const validNamespaces = [
+    'string',
+    'number',
+    'video',
+    'list',
+    'json',
+    'time',
+    'csv',
+    'pdf',
+    'audio',
+    'xml',
+    'translation',
+    'image'
+  ];
+  const isValidI18nNamespace = (value) => {
+    return validNamespaces.includes(value);
+  };
 
-  return 'translation';
-};
+  const getI18nNamespaceFromToolCategory = (category) => {
+    // Map image-related categories to 'image'
+    if (['png', 'image-generic'].includes(category)) {
+      return 'image';
+    } else if (['gif'].includes(category)) {
+      return 'video';
+    }
+    // Use type guard to check if category is a valid I18nNamespaces
+    if (isValidI18nNamespace(category)) {
+      return category;
+    }
 
-const i18nNamespace = getI18nNamespaceFromToolCategory(type);
-createToolFile(
-  `meta.ts`,
-  `
+    return 'translation';
+  };
+
+  const i18nNamespace = getI18nNamespaceFromToolCategory(type);
+  await createToolFile(
+    `meta.ts`,
+    `
 import { defineTool } from '@tools/defineTool';
 import { lazy } from 'react';
 
@@ -191,29 +195,29 @@ export const tool = defineTool('${type}', {
   component: lazy(() => import('./index'))
 });
 `
-);
+  );
 
-createToolFile(
-  `service.ts`,
-  `
+  await createToolFile(
+    `service.ts`,
+    `
 import { InitialValuesType } from './types';
 
 export function main(input: string, options: InitialValuesType): string {
   return input;
 }
 `
-);
-createToolFile(
-  `types.ts`,
-  `
+  );
+  await createToolFile(
+    `types.ts`,
+    `
 export type InitialValuesType = {
   // splitSeparator: string;
 };
 `
-);
-createToolFile(
-  `${toolName}.service.test.ts`,
-  `
+  );
+  await createToolFile(
+    `${toolName}.service.test.ts`,
+    `
 import { expect, describe, it } from 'vitest';
 // import { main } from './service';
 //
@@ -221,67 +225,75 @@ import { expect, describe, it } from 'vitest';
 //
 // })
 `
-);
+  );
 
-// createToolFile(
-//   `${toolName}.e2e.spec.ts`,
-//   `
-// import { test, expect } from '@playwright/test';
-//
-// test.describe('Tool - ${toolNameTitleCase}', () => {
-//   test.beforeEach(async ({ page }) => {
-//     await page.goto('/${toolName}');
-//   });
-//
-//   test('Has correct title', async ({ page }) => {
-//     await expect(page).toHaveTitle('${toolNameTitleCase} - IT Tools');
-//   });
-//
-//   test('', async ({ page }) => {
-//
-//   });
-// });
-//
-// `
-// )
+  // createToolFile(
+  //   `${toolName}.e2e.spec.ts`,
+  //   `
+  // import { test, expect } from '@playwright/test';
+  //
+  // test.describe('Tool - ${toolNameTitleCase}', () => {
+  //   test.beforeEach(async ({ page }) => {
+  //     await page.goto('/${toolName}');
+  //   });
+  //
+  //   test('Has correct title', async ({ page }) => {
+  //     await expect(page).toHaveTitle('${toolNameTitleCase} - IT Tools');
+  //   });
+  //
+  //   test('', async ({ page }) => {
+  //
+  //   });
+  // });
+  //
+  // `
+  // )
 
-const toolsIndex = join(toolsDir, 'index.ts');
-const indexContent = await readFile(toolsIndex, { encoding: 'utf-8' }).then(
-  (r) => r.split('\n')
-);
+  const toolsIndex = join(toolsDir, 'index.ts');
+  const indexContent = await readFile(toolsIndex, { encoding: 'utf-8' }).then(
+    (r) => r.split('\n')
+  );
 
-indexContent.splice(
-  0,
-  0,
-  `import { tool as ${type}${capitalizeFirstLetter(
-    toolNameCamelCase
-  )} } from './${toolName}/meta';`
-);
-writeFile(toolsIndex, indexContent.join('\n'));
+  indexContent.splice(
+    0,
+    0,
+    `import { tool as ${type}${capitalizeFirstLetter(
+      toolNameCamelCase
+    )} } from './${toolName}/meta';`
+  );
+  await writeFile(toolsIndex, indexContent.join('\n'));
 
-// Update locale JSON file
-const localeFilePath = join(
-  currentDirname,
-  '..',
-  'public',
-  'locales',
-  'en',
-  `${i18nNamespace}.json`
-);
+  // Update locale JSON file
+  const localeFilePath = join(
+    currentDirname,
+    '..',
+    'public',
+    'locales',
+    'en',
+    `${i18nNamespace}.json`
+  );
 
-let localeData = {};
-if (fs.existsSync(localeFilePath)) {
-  const localeContent = await readFile(localeFilePath, { encoding: 'utf-8' });
-  localeData = JSON.parse(localeContent);
+  let localeData = {};
+  if (fs.existsSync(localeFilePath)) {
+    const localeContent = await readFile(localeFilePath, { encoding: 'utf-8' });
+    localeData = JSON.parse(localeContent);
+  }
+
+  localeData[toolNameCamelCase] = {
+    title: toolNameTitleCase,
+    description: '',
+    shortDescription: '',
+    longDescription: ''
+  };
+
+  // Write updated locale file
+  await writeFile(localeFilePath, JSON.stringify(localeData, null, 2));
+  console.log(`Added import in: ${toolsIndex}`);
 }
 
-localeData[toolNameCamelCase] = {
-  title: toolNameTitleCase,
-  description: '',
-  shortDescription: '',
-  longDescription: ''
-};
-
-// Write updated locale file
-await writeFile(localeFilePath, JSON.stringify(localeData, null, 2));
-console.log(`Added import in: ${toolsIndex}`);
+if (
+  process.argv[1] &&
+  resolve(process.argv[1]) === fileURLToPath(import.meta.url)
+) {
+  await main();
+}

--- a/scripts/create-tool.test.ts
+++ b/scripts/create-tool.test.ts
@@ -1,0 +1,53 @@
+import { existsSync } from 'fs';
+import { mkdtemp, rm } from 'fs/promises';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { createFolderStructure } from './create-tool.mjs';
+
+const createdDirs: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    createdDirs
+      .splice(0)
+      .map((dir) => rm(dir, { recursive: true, force: true }))
+  );
+});
+
+describe('createFolderStructure', () => {
+  it('creates nested folders from an absolute path', async () => {
+    const tempRoot = await mkdtemp(join(tmpdir(), 'omni-tools-create-tool-'));
+    createdDirs.push(tempRoot);
+
+    const toolDir = join(
+      tempRoot,
+      'src',
+      'pages',
+      'tools',
+      'image',
+      'generic',
+      'split'
+    );
+
+    createFolderStructure(toolDir, 2);
+
+    expect(existsSync(join(tempRoot, 'src', 'pages', 'tools', 'image'))).toBe(
+      true
+    );
+    expect(
+      existsSync(join(tempRoot, 'src', 'pages', 'tools', 'image', 'index.ts'))
+    ).toBe(true);
+    expect(
+      existsSync(
+        join(tempRoot, 'src', 'pages', 'tools', 'image', 'generic', 'index.ts')
+      )
+    ).toBe(true);
+    expect(
+      existsSync(
+        join(tempRoot, 'src', 'pages', 'tools', 'image', 'generic', 'split')
+      )
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary\n- resolve the target tool path before creating nested directories\n- write generated files sequentially and expose helpers for testing\n- add a regression test for absolute path folder creation\n\n## Testing\n- npx vitest run scripts/create-tool.test.ts\n\nFixes #235\n