### PR TITLE
fix: rename 'Compress PNG' to 'Downsample PNG' to clarify destructive behavior

### DIFF
--- a/public/locales/en/image.json
+++ b/public/locales/en/image.json
@@ -26,9 +26,9 @@
     "title": "Compress Images"
   },
   "compressPng": {
-    "description": "This is a program that compresses PNG pictures. As soon as you paste your PNG picture in the input area, the program will compress it and show the result in the output area. In the options, you can adjust the compression level, as well as find the old and new picture file sizes.",
-    "shortDescription": "Quickly compress a PNG",
-    "title": "Compress png"
+    "description": "Reduces PNG file size by downsampling (lowering) image resolution and dimensions. Warning: This is a destructive operation that permanently reduces image quality — it cannot be undone. Unlike lossless compression, downsampling permanently removes pixel data.",
+    "shortDescription": "Reduce PNG size by downsampling resolution",
+    "title": "Downsample PNG"
   },
   "convertJgpToPng": {
     "description": "Quickly convert your JPG images to PNG. Just import your PNG image in the editor on the left",

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -98,7 +98,7 @@
     "examples": {
       "calculateNumberSum": "Calculate number sum",
       "changeGifSpeed": "Change GIF speed",
-      "compressPng": "Compress PNG",
+      "compressPng": "Downsample PNG",
       "createTransparentImage": "Create a transparent image",
       "prettifyJson": "Prettify JSON",
       "sortList": "Sort a list",

--- a/src/pages/tools/image/png/compress-png/meta.ts
+++ b/src/pages/tools/image/png/compress-png/meta.ts
@@ -12,6 +12,6 @@ export const tool = defineTool('png', {
   path: 'compress-png',
   icon: 'material-symbols-light:compress',
 
-  keywords: ['compress', 'png'],
+  keywords: ['compress', 'png', 'downsample', 'resize'],
   component: lazy(() => import('./index'))
 });


### PR DESCRIPTION
## Summary
Renames the 'Compress PNG' tool to 'Downsample PNG' and updates its description to clearly warn users that this tool reduces image resolution/dimensions (destructive), rather than just losslessly compressing file size.

## Changes
- **public/locales/en/image.json**: Updated title to 'Downsample PNG', updated shortDescription and description to clarify the destructive downsampling behavior
- **public/locales/en/translation.json**: Updated sidebar label from 'Compress PNG' to 'Downsample PNG'
- **src/pages/tools/image/png/compress-png/meta.ts**: Added 'downsample' and 'resize' keywords for discoverability

## Motivation
Issue #30 reported that the name 'Compress PNG' is misleading — users expect lossless compression, but the tool actually reduces image resolution/dimensions, which is a destructive operation. The new name and description make this clear.

## Testing
- [ ] Verified the tool still functions after renaming
- [ ] i18n keys remain consistent

Closes #30