### PR TITLE
Security: Arbitrary code execution via `eval` in JSON stringify tool

### DIFF
--- a/src/pages/tools/json/stringify/service.ts
+++ b/src/pages/tools/json/stringify/service.ts
@@ -6,10 +6,9 @@ export const stringifyJson = (
 ): string => {
   let parsedInput;
   try {
-    // Safely evaluate the input string as JavaScript
-    parsedInput = eval('(' + input + ')');
+    parsedInput = JSON.parse(input);
   } catch (e) {
-    throw new Error('Invalid JavaScript object/array');
+    throw new Error('Invalid JSON');
   }
 
   const indent = indentationType === 'tab' ? '\t' : ' '.repeat(spacesCount);


### PR DESCRIPTION
## Problem

The `stringifyJson` function parses user input using `eval('(' + input + ')')`. This allows execution of arbitrary JavaScript expressions supplied in input, not just data parsing. In a browser context, this can lead to script execution in the application's origin (e.g., accessing localStorage, making authenticated requests, or tampering with UI state).

**Severity**: `high`
**File**: `src/pages/tools/json/stringify/service.ts`

## Solution

Replace `eval` with safe parsing. If only JSON is required, use `JSON.parse`. If JavaScript object literal support is needed, use a dedicated safe parser (e.g., JSON5 parser) and reject executable syntax. Never evaluate raw user input.

## Changes

- `src/pages/tools/json/stringify/service.ts` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
