### PR TITLE
Added warning for long signature clipping in PDF editor

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
   <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
   <meta name="apple-mobile-web-app-title" content="OmniTools" />
   <link rel="manifest" href="/site.webmanifest" />
-  <link href="/assets/fonts/qu`icksand/quick-sand.css" rel="stylesheet" />
+  <link href="/assets/fonts/quicksand/quick-sand.css" rel="stylesheet" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>OmniTools</title>
 </head>

--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
   <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
   <meta name="apple-mobile-web-app-title" content="OmniTools" />
   <link rel="manifest" href="/site.webmanifest" />
-  <link href="/assets/fonts/quicksand/quick-sand.css" rel="stylesheet" />
+  <link href="/assets/fonts/qu`icksand/quick-sand.css" rel="stylesheet" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>OmniTools</title>
 </head>

--- a/package-lock.json
+++ b/package-lock.json
@@ -3536,7 +3536,6 @@
       "version": "18.3.7",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
       "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
-      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^18.0.0"
@@ -3597,7 +3596,6 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-1.0.6.tgz",
       "integrity": "sha512-230RC8sFeHoT6sSUlRO6a8cAnclO06eeiq1QDfiv2FGCLWFvvERWgwIQD4FWqD9A69BN7Lzee4OXwoMVnnsWDw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
@@ -5860,7 +5858,7 @@
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
       "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "iconv-lite": "^0.6.2"
@@ -7803,7 +7801,7 @@
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
       "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
@@ -9525,7 +9523,6 @@
       "version": "0.53.0",
       "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.53.0.tgz",
       "integrity": "sha512-0WNThgC6CMWNXXBxTbaYYcunj08iB5rnx4/G56UOPeL9UVIUGGHA1GR0EWIh9Ebabj7NpCRawQ5b0hfN1jQmYQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/trusted-types": "^1.0.6"
@@ -11732,7 +11729,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/sax": {
@@ -13226,7 +13223,7 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",

--- a/src/pages/tools/pdf/editor/index.tsx
+++ b/src/pages/tools/pdf/editor/index.tsx
@@ -13,6 +13,14 @@ export default function PdfEditor({ title }: ToolComponentProps) {
       input={null}
       inputComponent={
         <Box sx={{ width: '100%', height: '80vh' }}>
+          {/* Warning message */}
+          <Box
+            sx={{ mb: 1, color: '#ff9800', fontSize: '14px', fontWeight: 500 }}
+          >
+            Note: Long signatures may be cut in exported PDF.
+          </Box>
+
+          {/* PDF Editor */}
           <EmbedPDF mode="inline" style={{ width: '100%', height: '100%' }} />
         </Box>
       }


### PR DESCRIPTION
Added a warning message above the PDF editor to inform users that long signatures may be clipped in exported PDFs.