### PR TITLE
feat(pdf): add PDF to Word (.docx) converter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
         "cronstrue": "^3.0.0",
         "dayjs": "^1.11.13",
         "diff": "^8.0.2",
+        "docx": "^9.6.1",
         "dompurify": "^3.4.2",
         "fast-xml-parser": "^5.2.5",
         "formik": "^2.4.6",
@@ -5691,6 +5692,56 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/docx": {
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/docx/-/docx-9.6.1.tgz",
+      "integrity": "sha512-ZJja9/KBUuFC109sCMzovoq2GR2wCG/AuxivjA+OHj/q0TEgJIm3S7yrlUxIy3B+bV8YDj/BiHfWyrRFmyWpDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^25.2.3",
+        "hash.js": "^1.1.7",
+        "jszip": "^3.10.1",
+        "nanoid": "^5.1.3",
+        "xml": "^1.0.1",
+        "xml-js": "^1.6.8"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/docx/node_modules/@types/node": {
+      "version": "25.6.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
+      "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.19.0"
+      }
+    },
+    "node_modules/docx/node_modules/nanoid": {
+      "version": "5.1.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.11.tgz",
+      "integrity": "sha512-v+KEsUv2ps74PaSKv0gHTxTCgMXOIfBEbaqa6w6ISIGC7ZsvHN4N9oJ8d4cmf0n5oTzQz2SLmThbQWhjd/8eKg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.js"
+      },
+      "engines": {
+        "node": "^18 || >=20"
+      }
+    },
+    "node_modules/docx/node_modules/undici-types": {
+      "version": "7.19.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
+      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
+      "license": "MIT"
+    },
     "node_modules/dom-accessibility-api": {
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
@@ -7600,6 +7651,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/hash.js": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
+      "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "minimalistic-assert": "^1.0.1"
+      }
+    },
     "node_modules/hasown": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
@@ -9457,6 +9518,12 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/minimalistic-assert": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
+      "license": "ISC"
     },
     "node_modules/minimatch": {
       "version": "9.0.3",
@@ -13960,11 +14027,16 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/xml": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/xml/-/xml-1.0.1.tgz",
+      "integrity": "sha512-huCv9IH9Tcf95zuYCsQraZtWnJvBtLVE0QHMOs8bWyZAFZNDcYjsPq1nEx8jKA9y+Beo9v+7OBPRisQTjinQMw==",
+      "license": "MIT"
+    },
     "node_modules/xml-js": {
       "version": "1.6.11",
       "resolved": "https://registry.npmjs.org/xml-js/-/xml-js-1.6.11.tgz",
       "integrity": "sha512-7rVi2KMfwfWFl+GpPg6m80IVMWXLRjO+PxTq7V2CDhoGak0wzYzFgUY2m4XJ47OGdXd8eLE8EmwfAmdjw7lC1g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "sax": "^1.2.4"

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "cronstrue": "^3.0.0",
     "dayjs": "^1.11.13",
     "diff": "^8.0.2",
+    "docx": "^9.6.1",
     "dompurify": "^3.4.2",
     "fast-xml-parser": "^5.2.5",
     "formik": "^2.4.6",

--- a/public/locales/de/pdf.json
+++ b/public/locales/de/pdf.json
@@ -115,5 +115,10 @@
       "description": "Mit diesem Tool können Sie bestimmte Seiten aus einem PDF-Dokument extrahieren. Sie können einzelne Seiten oder Seitenbereiche zum Extrahieren angeben.",
       "title": "PDF teilen"
     }
+  },
+  "pdfToWord": {
+    "title": "PDF to Word",
+    "description": "Convert PDF documents into editable Word (.docx) files.",
+    "shortDescription": "Convert PDF files to Word format"
   }
 }

--- a/public/locales/en/pdf.json
+++ b/public/locales/en/pdf.json
@@ -135,5 +135,10 @@
     "title": "Extract Images from PDF",
     "inputTitle": "Input PDF",
     "resultTitle": "Extracted Images"
+  },
+  "pdfToWord": {
+    "title": "PDF to Word",
+    "description": "Convert PDF documents into editable Word (.docx) files.",
+    "shortDescription": "Convert PDF files to Word format"
   }
 }

--- a/public/locales/es/pdf.json
+++ b/public/locales/es/pdf.json
@@ -115,5 +115,10 @@
       "description": "Esta herramienta permite extraer páginas específicas de un documento PDF. Puede especificar páginas individuales o un rango de páginas para extraer.",
       "title": "PDF dividido"
     }
+  },
+  "pdfToWord": {
+    "title": "PDF to Word",
+    "description": "Convert PDF documents into editable Word (.docx) files.",
+    "shortDescription": "Convert PDF files to Word format"
   }
 }

--- a/public/locales/fr/pdf.json
+++ b/public/locales/fr/pdf.json
@@ -115,5 +115,10 @@
       "description": "Cet outil vous permet d'extraire des pages spécifiques d'un document PDF. Vous pouvez spécifier des pages individuelles ou des plages de pages à extraire.",
       "title": "Diviser le PDF"
     }
+  },
+  "pdfToWord": {
+    "title": "PDF to Word",
+    "description": "Convert PDF documents into editable Word (.docx) files.",
+    "shortDescription": "Convert PDF files to Word format"
   }
 }

--- a/public/locales/hi/pdf.json
+++ b/public/locales/hi/pdf.json
@@ -161,5 +161,10 @@
       "description": "यह टूल आपको किसी PDF दस्तावेज़ से विशिष्ट पृष्ठ निकालने की सुविधा देता है। आप निकालने के लिए अलग-अलग पृष्ठ या पृष्ठों की श्रेणी निर्दिष्ट कर सकते हैं।",
       "title": "PDF विभाजित करें"
     }
+  },
+  "pdfToWord": {
+    "title": "PDF to Word",
+    "description": "Convert PDF documents into editable Word (.docx) files.",
+    "shortDescription": "Convert PDF files to Word format"
   }
 }

--- a/public/locales/ja/pdf.json
+++ b/public/locales/ja/pdf.json
@@ -115,5 +115,10 @@
       "description": "このツールを使うと、PDF文書から特定のページを抽出できます。抽出するページは、個々のページまたはページ範囲で指定できます。",
       "title": "PDFを分割"
     }
+  },
+  "pdfToWord": {
+    "title": "PDF to Word",
+    "description": "Convert PDF documents into editable Word (.docx) files.",
+    "shortDescription": "Convert PDF files to Word format"
   }
 }

--- a/public/locales/nl/pdf.json
+++ b/public/locales/nl/pdf.json
@@ -115,5 +115,10 @@
       "description": "Met deze tool kunt u specifieke pagina's uit een PDF-document extraheren. U kunt specifieke pagina's of paginareeksen opgeven die u wilt extraheren.",
       "title": "PDF splitsen"
     }
+  },
+  "pdfToWord": {
+    "title": "PDF to Word",
+    "description": "Convert PDF documents into editable Word (.docx) files.",
+    "shortDescription": "Convert PDF files to Word format"
   }
 }

--- a/public/locales/pt/pdf.json
+++ b/public/locales/pt/pdf.json
@@ -115,5 +115,10 @@
       "description": "Esta ferramenta permite extrair páginas específicas de um documento PDF. Você pode especificar páginas individuais ou intervalos de páginas para extrair.",
       "title": "Dividir PDF"
     }
+  },
+  "pdfToWord": {
+    "title": "PDF to Word",
+    "description": "Convert PDF documents into editable Word (.docx) files.",
+    "shortDescription": "Convert PDF files to Word format"
   }
 }

--- a/public/locales/ru/pdf.json
+++ b/public/locales/ru/pdf.json
@@ -115,5 +115,10 @@
       "description": "Этот инструмент позволяет извлекать определённые страницы из PDF-документа. Вы можете указать отдельные страницы или диапазоны страниц для извлечения.",
       "title": "Разделить PDF"
     }
+  },
+  "pdfToWord": {
+    "title": "PDF to Word",
+    "description": "Convert PDF documents into editable Word (.docx) files.",
+    "shortDescription": "Convert PDF files to Word format"
   }
 }

--- a/public/locales/zh/pdf.json
+++ b/public/locales/zh/pdf.json
@@ -115,5 +115,10 @@
       "description": "此工具允许您从 PDF 文档中提取特定页面。您可以指定要提取的单个页面或页面范围。",
       "title": "拆分 PDF"
     }
+  },
+  "pdfToWord": {
+    "title": "PDF to Word",
+    "description": "Convert PDF documents into editable Word (.docx) files.",
+    "shortDescription": "Convert PDF files to Word format"
   }
 }

--- a/src/pages/tools/pdf/index.ts
+++ b/src/pages/tools/pdf/index.ts
@@ -9,6 +9,7 @@ import { meta as pdfToEpub } from './pdf-to-epub/meta';
 import { tool as pdfEditor } from './editor/meta';
 import { tool as convertToPdf } from './convert-to-pdf/meta';
 import { meta as extractImageFromPdf } from './extract-images-from-pdf/meta';
+import { meta as pdfToWord } from './pdf-to-word/meta';
 
 export const pdfTools: DefinedTool[] = [
   pdfEditor,
@@ -20,5 +21,6 @@ export const pdfTools: DefinedTool[] = [
   pdfToEpub,
   pdfPdfToPng,
   convertToPdf,
-  extractImageFromPdf
+  extractImageFromPdf,
+  pdfToWord
 ];

--- a/src/pages/tools/pdf/pdf-to-word/index.tsx
+++ b/src/pages/tools/pdf/pdf-to-word/index.tsx
@@ -1,0 +1,58 @@
+import { useState } from 'react';
+import ToolContent from '@components/ToolContent';
+import ToolPdfInput from '@components/input/ToolPdfInput';
+import { ToolComponentProps } from '@tools/defineTool';
+import ToolFileResult from '@components/result/ToolFileResult';
+import { convertPdfToWord } from './service';
+
+export default function PdfToWord({ title }: ToolComponentProps) {
+  const [input, setInput] = useState<File | null>(null);
+  const [result, setResult] = useState<File | null>(null);
+  const [isProcessing, setIsProcessing] = useState(false);
+
+  const compute = async (_: {}, file: File | null) => {
+    if (!file) return;
+    setIsProcessing(true);
+    setResult(null);
+    try {
+      setResult(await convertPdfToWord(file));
+    } catch (err) {
+      console.error('Conversion failed:', err);
+    } finally {
+      setIsProcessing(false);
+    }
+  };
+
+  return (
+    <ToolContent
+      title={title}
+      input={input}
+      setInput={setInput}
+      initialValues={{}}
+      compute={compute}
+      inputComponent={
+        <ToolPdfInput
+          value={input}
+          onChange={setInput}
+          accept={['application/pdf']}
+          title="Input PDF"
+        />
+      }
+      getGroups={null}
+      resultComponent={
+        <ToolFileResult
+          title="Word Output"
+          value={result}
+          extension="docx"
+          loading={isProcessing}
+          loadingText="Converting PDF to Word..."
+        />
+      }
+      toolInfo={{
+        title: 'How to Use PDF to Word?',
+        description:
+          'Upload a PDF file and this tool will extract the text and convert it into a .docx Word document, compatible with Microsoft Word and other word processors.'
+      }}
+    />
+  );
+}

--- a/src/pages/tools/pdf/pdf-to-word/meta.ts
+++ b/src/pages/tools/pdf/pdf-to-word/meta.ts
@@ -1,0 +1,15 @@
+import { defineTool } from '@tools/defineTool';
+import { lazy } from 'react';
+
+export const meta = defineTool('pdf', {
+  icon: 'material-symbols:description',
+  component: lazy(() => import('./index')),
+  keywords: ['pdf', 'word', 'docx', 'convert', 'document'],
+  path: 'pdf-to-word',
+  i18n: {
+    name: 'pdf:pdfToWord.title',
+    description: 'pdf:pdfToWord.description',
+    shortDescription: 'pdf:pdfToWord.shortDescription',
+    userTypes: ['generalUsers']
+  }
+});

--- a/src/pages/tools/pdf/pdf-to-word/service.ts
+++ b/src/pages/tools/pdf/pdf-to-word/service.ts
@@ -1,0 +1,34 @@
+import * as pdfjsLib from 'pdfjs-dist';
+import pdfjsWorker from 'pdfjs-dist/build/pdf.worker.min?url';
+import { Document, Packer, Paragraph, TextRun } from 'docx';
+
+pdfjsLib.GlobalWorkerOptions.workerSrc = pdfjsWorker;
+
+export async function convertPdfToWord(pdfFile: File): Promise<File> {
+  const arrayBuffer = await pdfFile.arrayBuffer();
+  const pdfDoc = await pdfjsLib.getDocument({ data: arrayBuffer }).promise;
+
+  const paragraphs: Paragraph[] = [];
+
+  for (let i = 1; i <= pdfDoc.numPages; i++) {
+    const page = await pdfDoc.getPage(i);
+    const textContent = await page.getTextContent();
+    const pageText = textContent.items.map((item: any) => item.str).join(' ').trim();
+
+    if (pageText) {
+      paragraphs.push(new Paragraph({ children: [new TextRun(pageText)] }));
+    }
+
+    // Page break between pages (except last)
+    if (i < pdfDoc.numPages) {
+      paragraphs.push(new Paragraph({ pageBreakBefore: true, children: [] }));
+    }
+  }
+
+  const doc = new Document({ sections: [{ children: paragraphs }] });
+  const blob = await Packer.toBlob(doc);
+
+  return new File([blob], pdfFile.name.replace(/\.pdf$/i, '.docx'), {
+    type: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document'
+  });
+}


### PR DESCRIPTION
## Summary

Implements the PDF to Word conversion tool requested in #69.

## Changes
- New tool at `/pdf-to-word` route
- Extracts text from each PDF page using `pdfjs-dist`
- Generates a `.docx` file using the `docx` library (browser-compatible)
- i18n strings added for all 10 supported locales (en, de, es, fr, hi, ja, nl, pt, ru, zh)
- Tool registered in the PDF tools index

## How it works
1. User uploads a PDF
2. Text is extracted page-by-page via pdfjs-dist
3. Each page becomes a paragraph in the Word document with page breaks between pages
4. Output is a downloadable `.docx` file

Closes #69