### PR TITLE
fix: correct absolute path creation in create-tool script 

### DIFF
--- a/scripts/create-tool.mjs
+++ b/scripts/create-tool.mjs
@@ -54,7 +54,7 @@ function createFolderStructure(basePath, foldersToCreateIndexCount) {
   }
 
   // Start the recursive folder creation
-  recursiveCreate('.', 0);
+  recursiveCreate(sep, 0);
 }
 
 const toolNameCamelCase = toolName.replace(/-./g, (x) => x[1].toUpperCase());


### PR DESCRIPTION
## Description

This PR fixes an issue in the `create-tool` scaffold script where tool generation failed on Unix-based systems due to incorrect absolute path handling.

### Problem

Running the scaffold generator command resulted in partially created directories followed by an `ENOENT` error during file creation.

Example failure:

```bash
Error: ENOENT: no such file or directory
```

The issue occurred because recursive directory creation was initialized using a relative root (`.`) even when processing absolute paths.

As a result, directories were incorrectly generated as relative paths such as:

```text
home/user/project/...
```

instead of the expected absolute paths:

```text
/home/user/project/...
```

This caused subsequent scaffold files (such as `index.tsx`) to fail during creation because the target absolute directory structure did not actually exist.

### Root Cause

Inside `createFolderStructure()`, recursive folder creation was initialized with:

```js
recursiveCreate('.', 0);
```

Using `.` as the starting base path caused absolute path segments to be resolved relative to the current working directory during recursive joins.

### Fix

The recursive creation process now starts from the filesystem root using:

```js
recursiveCreate(sep, 0);
```

This ensures absolute paths are preserved correctly during recursive directory creation and allows the scaffold generator to successfully create all required files and directories on Unix-based systems.
