### PR TITLE
fix: use Web Crypto for password generation

### DIFF
--- a/src/pages/tools/string/password-generator/password-generator.service.test.ts
+++ b/src/pages/tools/string/password-generator/password-generator.service.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { generatePassword } from './service';
 import { initialValues } from './initialValues';
 
@@ -139,5 +139,14 @@ describe('generatePassword', () => {
     const options = { ...initialValues, length: '-5' };
     const result = generatePassword(options);
     expect(result).toBe('');
+  });
+
+  it('should not use Math.random for password generation', () => {
+    const mathRandomSpy = vi.spyOn(Math, 'random');
+
+    generatePassword({ ...initialValues, length: '10' });
+
+    expect(mathRandomSpy).not.toHaveBeenCalled();
+    mathRandomSpy.mockRestore();
   });
 });

--- a/src/pages/tools/string/password-generator/service.ts
+++ b/src/pages/tools/string/password-generator/service.ts
@@ -1,5 +1,16 @@
 import type { InitialValuesType } from './initialValues';
 
+function getSecureRandomIndex(max: number): number {
+  const randomValue = new Uint32Array(1);
+  const maxUnbiasedValue = Math.floor(0x100000000 / max) * max;
+
+  do {
+    globalThis.crypto.getRandomValues(randomValue);
+  } while (randomValue[0] >= maxUnbiasedValue);
+
+  return randomValue[0] % max;
+}
+
 export function generatePassword(options: InitialValuesType): string {
   const length = parseInt(options.length || '', 10);
   if (isNaN(length) || length <= 0) {
@@ -31,7 +42,7 @@ export function generatePassword(options: InitialValuesType): string {
 
   let pwd = '';
   for (let i = 0; i < length; i++) {
-    const idx = Math.floor(Math.random() * charset.length);
+    const idx = getSecureRandomIndex(charset.length);
     pwd += charset[idx];
   }
   return pwd;


### PR DESCRIPTION
## Summary
- Replace Math.random() with Web Crypto-based random selection for generated passwords
- Use rejection sampling to avoid modulo bias when selecting characters
- Add a service test to guard against Math.random() being used for password generation

Fixes #376.

## Testing
- npx vitest run src/pages/tools/string/password-generator/password-generator.service.test.ts
- npx eslint src/pages/tools/string/password-generator/service.ts src/pages/tools/string/password-generator/password-generator.service.test.ts

Note: npm run typecheck currently fails on existing unrelated missing declarations for heic-to and diff.