### PR TITLE
fix(json-to-xml): add recursion depth guard and sanitize XML tag names

### DIFF
--- a/src/pages/tools/json/json-to-xml/service.test.ts
+++ b/src/pages/tools/json/json-to-xml/service.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest';
+import { convertJsonToXml } from './service';
+
+const opts = { indentationType: 'none' as const, addMetaTag: false };
+
+describe('convertJsonToXml', () => {
+  it('converts a flat object', () => {
+    const result = convertJsonToXml('{"name":"Alice","age":30}', opts);
+    expect(result).toBe('<root><name>Alice</name><age>30</age></root>');
+  });
+
+  it('converts array values', () => {
+    const result = convertJsonToXml('{"items":[1,2]}', opts);
+    expect(result).toContain('<items>1</items>');
+    expect(result).toContain('<items>2</items>');
+  });
+
+  it('handles null values', () => {
+    const result = convertJsonToXml('{"x":null}', opts);
+    expect(result).toContain('<x></x>');
+  });
+
+  it('escapes special characters in values', () => {
+    const result = convertJsonToXml('{"k":"a&b<c>"}', opts);
+    expect(result).toContain('a&amp;b&lt;c&gt;');
+  });
+
+  describe('depth guard', () => {
+    it('throws when nesting exceeds MAX_DEPTH', () => {
+      // Build a 101-level deep object
+      let obj: any = { value: 1 };
+      for (let i = 0; i < 101; i++) {
+        obj = { nested: obj };
+      }
+      expect(() => convertJsonToXml(JSON.stringify(obj), opts)).toThrow(
+        /maximum depth/i
+      );
+    });
+
+    it('does not throw at exactly MAX_DEPTH - 1 levels', () => {
+      let obj: any = { value: 1 };
+      for (let i = 0; i < 98; i++) {
+        obj = { nested: obj };
+      }
+      expect(() => convertJsonToXml(JSON.stringify(obj), opts)).not.toThrow();
+    });
+  });
+
+  describe('XML tag name sanitization', () => {
+    it('replaces spaces with underscores', () => {
+      const result = convertJsonToXml('{"hello world":"v"}', opts);
+      expect(result).toContain('<hello_world>v</hello_world>');
+    });
+
+    it('prefixes numeric-start keys with underscore', () => {
+      const result = convertJsonToXml('{"1st":"gold"}', opts);
+      expect(result).toContain('<_1st>gold</_1st>');
+    });
+
+    it('replaces < and > in keys', () => {
+      const result = convertJsonToXml('{"a<b>c":"v"}', opts);
+      expect(result).toContain('<a_b_c>v</a_b_c>');
+    });
+
+    it('prefixes numeric array index keys with row-', () => {
+      const result = convertJsonToXml('{"items":[1,2,3]}', opts);
+      // array indices are numeric → row-0, row-1, row-2 → no sanitization needed
+      expect(result).toContain('<items>1</items>');
+    });
+  });
+});

--- a/src/pages/tools/json/json-to-xml/service.ts
+++ b/src/pages/tools/json/json-to-xml/service.ts
@@ -23,11 +23,27 @@ const getIndentation = (options: JsonToXmlOptions, depth: number): string => {
   }
 };
 
+const MAX_DEPTH = 100;
+
+const sanitizeXmlTagName = (key: string): string => {
+  // Prefix numeric-start keys so they become valid XML names
+  let tag = /^[0-9]/.test(key) ? `_${key}` : key;
+  // Replace any character that is not a letter, digit, underscore, or hyphen
+  tag = tag.replace(/[^a-zA-Z0-9_-]/g, '_');
+  return tag || '_';
+};
+
 const convertObjectToXml = (
   obj: any,
   options: JsonToXmlOptions,
   depth: number = 0
 ): string => {
+  if (depth >= MAX_DEPTH) {
+    throw new Error(
+      `JSON nesting exceeds maximum depth of ${MAX_DEPTH} levels`
+    );
+  }
+
   let xml = '';
 
   const newline = options.indentationType === 'none' ? '' : '\n';
@@ -41,7 +57,9 @@ const convertObjectToXml = (
 
   for (const key in obj) {
     const value = obj[key];
-    const keyString = isNaN(Number(key)) ? key : `row-${key}`;
+    const keyString = sanitizeXmlTagName(
+      isNaN(Number(key)) ? key : `row-${key}`
+    );
 
     // Handle null values
     if (value === null) {


### PR DESCRIPTION
## What does this PR fix?

Two bugs in the JSON → XML converter reported in #378:

### 1. Stack overflow on deeply nested JSON
`convertObjectToXml()` recurses without any depth limit. A deeply nested object (~5000+ levels) causes `RangeError: Maximum call stack size exceeded`, crashing the tool entirely.

**Fix:** Added a `MAX_DEPTH = 100` constant and a guard at the entry of `convertObjectToXml()` that throws a clear, user-readable error before the stack overflows.

```diff
+const MAX_DEPTH = 100;
+
 const convertObjectToXml = (obj, options, depth = 0) => {
+  if (depth >= MAX_DEPTH) {
+    throw new Error(`JSON nesting exceeds maximum depth of ${MAX_DEPTH} levels`);
+  }
```

### 2. Invalid XML tag names from special-character JSON keys
JSON keys were used as XML element names verbatim. Keys containing spaces, `<`, `>`, `&`, or other XML-illegal characters produce malformed XML. Keys starting with a digit also violate the XML Name production rule.

**Fix:** Added `sanitizeXmlTagName()` that:
- Replaces any character outside `[a-zA-Z0-9_-]` with `_`
- Prepends `_` when the key starts with a digit

```diff
+const sanitizeXmlTagName = (key: string): string => {
+  let tag = /^[0-9]/.test(key) ? `_${key}` : key;
+  tag = tag.replace(/[^a-zA-Z0-9_-]/g, '_');
+  return tag || '_';
+};
```

## Changes

| File | Change |
|---|---|
| `src/pages/tools/json/json-to-xml/service.ts` | +`MAX_DEPTH` constant, +`sanitizeXmlTagName()`, depth guard in `convertObjectToXml()` |
| `src/pages/tools/json/json-to-xml/service.test.ts` | New test file — 10 tests |

## Tests

```
✓ converts a flat object
✓ converts array values
✓ handles null values
✓ escapes special characters in values
✓ depth guard › throws when nesting exceeds MAX_DEPTH
✓ depth guard › does not throw at exactly MAX_DEPTH - 1 levels
✓ XML tag name sanitization › replaces spaces with underscores
✓ XML tag name sanitization › prefixes numeric-start keys with underscore
✓ XML tag name sanitization › replaces < and > in keys
✓ XML tag name sanitization › prefixes numeric array index keys with row-

Test Files  1 passed (1) | Tests  10 passed (10)
```

**AI disclosure:** fix developed with Claude Sonnet 4.6 (arimu1 reviewed and approved the diff)