### PR TITLE
feat: add URL editor tool

### DIFF
--- a/public/locales/en/string.json
+++ b/public/locales/en/string.json
@@ -312,6 +312,32 @@
     "shortDescription": "Convert text to uppercase",
     "title": "Convert to Uppercase"
   },
+  "urlEditor": {
+    "addParameter": "Add Parameter",
+    "delete": "Delete",
+    "generatedUrl": "Generated URL",
+    "hash": "Fragment",
+    "hashPlaceholder": "section",
+    "host": "Host",
+    "hostPlaceholder": "example.com",
+    "inputTitle": "Enter URL",
+    "invalidUrl": "Invalid URL",
+    "key": "Key",
+    "noParameters": "No query parameters",
+    "parseButton": "Parse URL",
+    "path": "Path",
+    "pathPlaceholder": "search",
+    "protocol": "Protocol",
+    "queryParameters": "Query Parameters",
+    "toolInfo": {
+      "description": "Paste a URL to inspect and edit its query parameters, then copy the updated link.",
+      "longDescription": "This tool parses a URL into its components and lets you edit the protocol, host, path, fragment, and query parameters visually. Add, remove, or change any part and the generated URL updates in real time. Everything runs in your browser with no server requests.",
+      "shortDescription": "Inspect and edit URL query parameters.",
+      "title": "URL Editor"
+    },
+    "urlDetails": "URL Details",
+    "value": "Value"
+  },
   "urlDecode": {
     "inputTitle": "Input String(URL-escaped)",
     "resultTitle": "Output string",

--- a/src/pages/tools/string/index.ts
+++ b/src/pages/tools/string/index.ts
@@ -22,6 +22,7 @@ import { tool as stringCensor } from './censor/meta';
 import { tool as stringPasswordGenerator } from './password-generator/meta';
 import { tool as stringEncodeUrl } from './url-encode/meta';
 import { tool as stringDecodeUrl } from './url-decode/meta';
+import { tool as stringUrlEditor } from './url-editor/meta';
 import { tool as stringCompare } from './text-compare/meta';
 import { tool as stringUnicode } from './unicode/meta';
 
@@ -48,6 +49,7 @@ export const stringTools = [
   stringPasswordGenerator,
   stringEncodeUrl,
   stringDecodeUrl,
+  stringUrlEditor,
   stringUnicode,
   stringHiddenCharacterDetector,
   stringCompare,

--- a/src/pages/tools/string/url-editor/UrlDetailsEditor.tsx
+++ b/src/pages/tools/string/url-editor/UrlDetailsEditor.tsx
@@ -1,0 +1,129 @@
+import {
+  Box,
+  FormControl,
+  Grid,
+  InputAdornment,
+  InputLabel,
+  MenuItem,
+  Select,
+  TextField
+} from '@mui/material';
+import { ParsedUrl } from './types';
+
+const PROTOCOLS = ['https:', 'http:'] as const;
+
+export type UrlDetailField = keyof Omit<ParsedUrl, 'params'>;
+
+type UrlDetailsEditorProps = {
+  value: ParsedUrl;
+  onChange: (field: UrlDetailField, value: string) => void;
+  labels: {
+    protocol: string;
+    host: string;
+    path: string;
+    hash: string;
+    hostPlaceholder: string;
+    pathPlaceholder: string;
+    hashPlaceholder: string;
+  };
+};
+
+export default function UrlDetailsEditor({
+  value,
+  onChange,
+  labels
+}: UrlDetailsEditorProps) {
+  const hashValue = value.hash.replace(/^#/, '');
+
+  return (
+    <Box
+      sx={{
+        border: 1,
+        borderRadius: 2,
+        borderColor: 'divider',
+        bgcolor: 'background.paper',
+        p: 2
+      }}
+    >
+      <Grid container spacing={2}>
+        <Grid item xs={12} sm={4} md={3}>
+          <FormControl fullWidth size="small">
+            <InputLabel id="url-editor-protocol">{labels.protocol}</InputLabel>
+            <Select
+              labelId="url-editor-protocol"
+              label={labels.protocol}
+              value={
+                PROTOCOLS.includes(value.protocol as (typeof PROTOCOLS)[number])
+                  ? value.protocol
+                  : 'https:'
+              }
+              onChange={(event) => onChange('protocol', event.target.value)}
+            >
+              {PROTOCOLS.map((protocol) => (
+                <MenuItem key={protocol} value={protocol}>
+                  {protocol.replace(':', '')}
+                </MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+        </Grid>
+
+        <Grid item xs={12} sm={8} md={9}>
+          <TextField
+            size="small"
+            fullWidth
+            label={labels.host}
+            placeholder={labels.hostPlaceholder}
+            value={value.host}
+            onChange={(event) => onChange('host', event.target.value)}
+            InputProps={{
+              startAdornment: (
+                <InputAdornment position="start">://</InputAdornment>
+              )
+            }}
+          />
+        </Grid>
+
+        <Grid item xs={12}>
+          <TextField
+            size="small"
+            fullWidth
+            label={labels.path}
+            placeholder={labels.pathPlaceholder}
+            value={value.pathname.replace(/^\//, '')}
+            onChange={(event) => {
+              const next = event.target.value.replace(/^\//, '');
+              onChange('pathname', next ? `/${next}` : '/');
+            }}
+            InputProps={{
+              startAdornment: (
+                <InputAdornment position="start">/</InputAdornment>
+              )
+            }}
+            inputProps={{ sx: { pl: 0.5 } }}
+          />
+        </Grid>
+
+        <Grid item xs={12}>
+          <TextField
+            size="small"
+            fullWidth
+            label={labels.hash}
+            placeholder={labels.hashPlaceholder}
+            value={hashValue}
+            onChange={(event) => {
+              const next = event.target.value.replace(/^#/, '');
+              onChange('hash', next ? `#${next}` : '');
+            }}
+            InputProps={{
+              startAdornment: (
+                <InputAdornment position="start">#</InputAdornment>
+              )
+            }}
+            inputProps={{ sx: { pl: 0.5 } }}
+          />
+        </Grid>
+      </Grid>
+    </Box>
+  );
+}

--- a/src/pages/tools/string/url-editor/index.tsx
+++ b/src/pages/tools/string/url-editor/index.tsx
@@ -1,0 +1,246 @@
+import { useCallback, useEffect, useState } from 'react';
+import {
+  Alert,
+  Box,
+  Button,
+  IconButton,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableRow,
+  TextField,
+  Typography
+} from '@mui/material';
+import DeleteIcon from '@mui/icons-material/Delete';
+import AddIcon from '@mui/icons-material/Add';
+import ToolContent from '@components/ToolContent';
+import ToolTextInput from '@components/input/ToolTextInput';
+import ToolTextResult from '@components/result/ToolTextResult';
+import InputHeader from '@components/InputHeader';
+import { ToolComponentProps } from '@tools/defineTool';
+import { useTranslation } from 'react-i18next';
+import UrlDetailsEditor, { UrlDetailField } from './UrlDetailsEditor';
+import { generateUrl, parseUrl } from './service';
+import { ParsedUrl } from './types';
+
+const initialValues = {};
+
+export default function UrlEditor({
+  title,
+  longDescription
+}: ToolComponentProps) {
+  const { t } = useTranslation('string');
+  const [inputUrl, setInputUrl] = useState('');
+  const [parsedUrl, setParsedUrl] = useState<ParsedUrl | null>(null);
+  const [generatedUrl, setGeneratedUrl] = useState('');
+  const [parseError, setParseError] = useState<string | null>(null);
+  const [generateError, setGenerateError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!parsedUrl) {
+      setGeneratedUrl('');
+      setGenerateError(null);
+      return;
+    }
+
+    try {
+      setGeneratedUrl(generateUrl(parsedUrl));
+      setGenerateError(null);
+    } catch {
+      setGeneratedUrl('');
+      setGenerateError(t('urlEditor.invalidUrl'));
+    }
+  }, [parsedUrl, t]);
+
+  const handleParse = useCallback(() => {
+    try {
+      setParsedUrl(parseUrl(inputUrl));
+      setParseError(null);
+    } catch {
+      setParsedUrl(null);
+      setParseError(t('urlEditor.invalidUrl'));
+    }
+  }, [inputUrl, t]);
+
+  const handleFieldChange = useCallback(
+    (field: UrlDetailField, value: string) => {
+      setParsedUrl((current) =>
+        current ? { ...current, [field]: value } : current
+      );
+    },
+    []
+  );
+
+  const handleAddParam = useCallback(() => {
+    setParsedUrl((current) =>
+      current
+        ? { ...current, params: [...current.params, { key: '', value: '' }] }
+        : current
+    );
+  }, []);
+
+  const handleRemoveParam = useCallback((index: number) => {
+    setParsedUrl((current) =>
+      current
+        ? {
+            ...current,
+            params: current.params.filter((_, i) => i !== index)
+          }
+        : current
+    );
+  }, []);
+
+  const handleParamChange = useCallback(
+    (index: number, field: 'key' | 'value', value: string) => {
+      setParsedUrl((current) => {
+        if (!current) return current;
+
+        const params = current.params.map((param, i) =>
+          i === index ? { ...param, [field]: value } : param
+        );
+
+        return { ...current, params };
+      });
+    },
+    []
+  );
+
+  return (
+    <ToolContent
+      title={title}
+      initialValues={initialValues}
+      getGroups={null}
+      compute={() => {}}
+      input={inputUrl}
+      setInput={setInputUrl}
+      inputComponent={
+        <Box>
+          <ToolTextInput
+            title={t('urlEditor.inputTitle')}
+            value={inputUrl}
+            onChange={setInputUrl}
+            placeholder="https://example.com/search?q=test"
+          />
+          <Box mt={2}>
+            <Button variant="contained" onClick={handleParse}>
+              {t('urlEditor.parseButton')}
+            </Button>
+          </Box>
+
+          {parseError && (
+            <Alert severity="error" sx={{ mt: 2 }}>
+              {parseError}
+            </Alert>
+          )}
+
+          {parsedUrl && (
+            <Box mt={3}>
+              <InputHeader title={t('urlEditor.urlDetails')} />
+              <UrlDetailsEditor
+                value={parsedUrl}
+                onChange={handleFieldChange}
+                labels={{
+                  protocol: t('urlEditor.protocol'),
+                  host: t('urlEditor.host'),
+                  path: t('urlEditor.path'),
+                  hash: t('urlEditor.hash'),
+                  hostPlaceholder: t('urlEditor.hostPlaceholder'),
+                  pathPlaceholder: t('urlEditor.pathPlaceholder'),
+                  hashPlaceholder: t('urlEditor.hashPlaceholder')
+                }}
+              />
+
+              <Box mt={3}>
+                <InputHeader title={t('urlEditor.queryParameters')} />
+                {parsedUrl.params.length > 0 ? (
+                  <Table size="small">
+                    <TableHead>
+                      <TableRow>
+                        <TableCell>{t('urlEditor.key')}</TableCell>
+                        <TableCell>{t('urlEditor.value')}</TableCell>
+                        <TableCell width={80} align="center">
+                          {t('urlEditor.delete')}
+                        </TableCell>
+                      </TableRow>
+                    </TableHead>
+                    <TableBody>
+                      {parsedUrl.params.map((param, index) => (
+                        <TableRow key={index}>
+                          <TableCell>
+                            <TextField
+                              value={param.key}
+                              onChange={(event) =>
+                                handleParamChange(
+                                  index,
+                                  'key',
+                                  event.target.value
+                                )
+                              }
+                              size="small"
+                              fullWidth
+                            />
+                          </TableCell>
+                          <TableCell>
+                            <TextField
+                              value={param.value}
+                              onChange={(event) =>
+                                handleParamChange(
+                                  index,
+                                  'value',
+                                  event.target.value
+                                )
+                              }
+                              size="small"
+                              fullWidth
+                            />
+                          </TableCell>
+                          <TableCell align="center">
+                            <IconButton
+                              aria-label={t('urlEditor.delete')}
+                              onClick={() => handleRemoveParam(index)}
+                              size="small"
+                            >
+                              <DeleteIcon fontSize="small" />
+                            </IconButton>
+                          </TableCell>
+                        </TableRow>
+                      ))}
+                    </TableBody>
+                  </Table>
+                ) : (
+                  <Typography variant="body2" color="text.secondary">
+                    {t('urlEditor.noParameters')}
+                  </Typography>
+                )}
+                <Button
+                  startIcon={<AddIcon />}
+                  onClick={handleAddParam}
+                  sx={{ mt: 2 }}
+                >
+                  {t('urlEditor.addParameter')}
+                </Button>
+              </Box>
+
+              {generateError && (
+                <Alert severity="warning" sx={{ mt: 2 }}>
+                  {generateError}
+                </Alert>
+              )}
+            </Box>
+          )}
+        </Box>
+      }
+      resultComponent={
+        <ToolTextResult
+          title={t('urlEditor.generatedUrl')}
+          value={generatedUrl}
+        />
+      }
+      toolInfo={{
+        title: t('urlEditor.toolInfo.title', { title }),
+        description: longDescription
+      }}
+    />
+  );
+}

--- a/src/pages/tools/string/url-editor/meta.ts
+++ b/src/pages/tools/string/url-editor/meta.ts
@@ -1,0 +1,25 @@
+import { defineTool } from '@tools/defineTool';
+import { lazy } from 'react';
+
+export const tool = defineTool('string', {
+  path: 'url-editor',
+  icon: 'mdi:link-edit',
+
+  keywords: [
+    'url',
+    'editor',
+    'query',
+    'parameters',
+    'parse',
+    'link',
+    'href',
+    'search params'
+  ],
+  component: lazy(() => import('./index')),
+  i18n: {
+    name: 'string:urlEditor.toolInfo.title',
+    description: 'string:urlEditor.toolInfo.description',
+    shortDescription: 'string:urlEditor.toolInfo.shortDescription',
+    longDescription: 'string:urlEditor.toolInfo.longDescription'
+  }
+});

--- a/src/pages/tools/string/url-editor/service.ts
+++ b/src/pages/tools/string/url-editor/service.ts
@@ -1,0 +1,56 @@
+import { ParsedUrl, QueryParam } from './types';
+
+export function parseUrl(input: string): ParsedUrl {
+  const trimmed = input.trim();
+  if (!trimmed) {
+    throw new Error('Invalid URL');
+  }
+
+  let url: URL;
+  try {
+    url = new URL(trimmed);
+  } catch {
+    throw new Error('Invalid URL');
+  }
+
+  const params: QueryParam[] = Array.from(url.searchParams.entries()).map(
+    ([key, value]) => ({ key, value })
+  );
+
+  return {
+    protocol: url.protocol,
+    host: url.host,
+    pathname: url.pathname,
+    hash: url.hash,
+    params
+  };
+}
+
+export function generateUrl(parsed: ParsedUrl): string {
+  const protocol = parsed.protocol || 'https:';
+  const host = parsed.host.trim();
+  if (!host) {
+    throw new Error('Invalid URL');
+  }
+
+  let pathname = parsed.pathname || '/';
+  if (!pathname.startsWith('/')) {
+    pathname = `/${pathname}`;
+  }
+
+  const url = new URL(`${protocol}//${host}${pathname}`);
+
+  let hash = parsed.hash.trim();
+  if (hash && !hash.startsWith('#')) {
+    hash = `#${hash}`;
+  }
+  url.hash = hash;
+
+  parsed.params.forEach(({ key, value }) => {
+    if (key) {
+      url.searchParams.append(key, value);
+    }
+  });
+
+  return url.toString();
+}

--- a/src/pages/tools/string/url-editor/types.ts
+++ b/src/pages/tools/string/url-editor/types.ts
@@ -1,0 +1,12 @@
+export interface QueryParam {
+  key: string;
+  value: string;
+}
+
+export interface ParsedUrl {
+  protocol: string;
+  host: string;
+  pathname: string;
+  hash: string;
+  params: QueryParam[];
+}

--- a/src/pages/tools/string/url-editor/url-editor.service.test.ts
+++ b/src/pages/tools/string/url-editor/url-editor.service.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from 'vitest';
+import { generateUrl, parseUrl } from './service';
+
+describe('url-editor', () => {
+  it('parses a valid URL with query parameters', () => {
+    expect(parseUrl('https://example.com/search?q=iphone&page=2')).toEqual({
+      protocol: 'https:',
+      host: 'example.com',
+      pathname: '/search',
+      hash: '',
+      params: [
+        { key: 'q', value: 'iphone' },
+        { key: 'page', value: '2' }
+      ]
+    });
+  });
+
+  it('parses multiple query parameters', () => {
+    expect(parseUrl('https://example.com?a=1&b=2&c=3').params).toEqual([
+      { key: 'a', value: '1' },
+      { key: 'b', value: '2' },
+      { key: 'c', value: '3' }
+    ]);
+  });
+
+  it('parses URLs without query parameters', () => {
+    expect(parseUrl('https://example.com')).toEqual({
+      protocol: 'https:',
+      host: 'example.com',
+      pathname: '/',
+      hash: '',
+      params: []
+    });
+  });
+
+  it('parses URLs with a hash', () => {
+    expect(parseUrl('https://example.com/page#section1')).toEqual({
+      protocol: 'https:',
+      host: 'example.com',
+      pathname: '/page',
+      hash: '#section1',
+      params: []
+    });
+  });
+
+  it('throws for invalid URLs', () => {
+    expect(() => parseUrl('abc123')).toThrow('Invalid URL');
+    expect(() => parseUrl('')).toThrow('Invalid URL');
+  });
+
+  it('generates an updated URL from parsed components', () => {
+    const parsed = parseUrl('https://example.com/search?q=iphone&page=2');
+    parsed.params = [
+      { key: 'q', value: 'samsung' },
+      { key: 'page', value: '5' }
+    ];
+
+    expect(generateUrl(parsed)).toBe(
+      'https://example.com/search?q=samsung&page=5'
+    );
+  });
+
+  it('round-trips URL components', () => {
+    const input = 'https://example.com/search?q=test&sort=desc#top';
+    expect(generateUrl(parseUrl(input))).toBe(input);
+  });
+
+  it('generates URL with edited host and path', () => {
+    const parsed = parseUrl('https://example.com/search?q=test');
+    parsed.host = 'github.com';
+    parsed.pathname = '/topics/open-source';
+
+    expect(generateUrl(parsed)).toBe(
+      'https://github.com/topics/open-source?q=test'
+    );
+  });
+
+  it('normalizes path without a leading slash', () => {
+    const parsed = parseUrl('https://example.com/search');
+    parsed.pathname = 'topics/open-source';
+
+    expect(generateUrl(parsed)).toBe('https://example.com/topics/open-source');
+  });
+
+  it('normalizes hash without a leading hash symbol', () => {
+    const parsed = parseUrl('https://example.com/page');
+    parsed.hash = 'section1';
+
+    expect(generateUrl(parsed)).toBe('https://example.com/page#section1');
+  });
+
+  it('throws when host is empty', () => {
+    const parsed = parseUrl('https://example.com');
+    parsed.host = '   ';
+
+    expect(() => generateUrl(parsed)).toThrow('Invalid URL');
+  });
+});


### PR DESCRIPTION
For issue  #384  asking for a URL editor 
Summary : Adds a new URL editor tool under the String category.

Features are : 
* Parse URLs into protocol, host, path, fragment, and query parameters
* Edit protocol, host, path, and fragment
* Add, edit, and remove query parameters
* Real-time URL generation
* Copy generated URL
* Validation for invalid URLs and empty hosts

 Implementation : 
* Added a dedicated URL Editor tool
* Separated UI, business logic, and types
* Added English translations
* Registered the tool in the String tools category

Tests: 
Added service tests covering:
* URL parsing
* URL generation
* Host/path editing
* Path/hash normalization
* Invalid URL handling
* Empty host handling
* Round-trip parse/generate consistency

All tests pass successfully.

