### PR TITLE
Feature/url editor

### DIFF
--- a/public/locales/en/string.json
+++ b/public/locales/en/string.json
@@ -312,6 +312,32 @@
     "shortDescription": "Convert text to uppercase",
     "title": "Convert to Uppercase"
   },
+  "urlEditor": {
+    "addParameter": "Add Parameter",
+    "delete": "Delete",
+    "generatedUrl": "Generated URL",
+    "hash": "Fragment",
+    "hashPlaceholder": "section",
+    "host": "Host",
+    "hostPlaceholder": "example.com",
+    "inputTitle": "Enter URL",
+    "invalidUrl": "Invalid URL",
+    "key": "Key",
+    "noParameters": "No query parameters",
+    "parseButton": "Parse URL",
+    "path": "Path",
+    "pathPlaceholder": "search",
+    "protocol": "Protocol",
+    "queryParameters": "Query Parameters",
+    "toolInfo": {
+      "description": "Paste a URL to inspect and edit its query parameters, then copy the updated link.",
+      "longDescription": "This tool parses a URL into its components and lets you edit the protocol, host, path, fragment, and query parameters visually. Add, remove, or change any part and the generated URL updates in real time. Everything runs in your browser with no server requests.",
+      "shortDescription": "Inspect and edit URL query parameters.",
+      "title": "URL Editor"
+    },
+    "urlDetails": "URL Details",
+    "value": "Value"
+  },
   "urlDecode": {
     "inputTitle": "Input String(URL-escaped)",
     "resultTitle": "Output string",

--- a/public/locales/en/string.json
+++ b/public/locales/en/string.json
@@ -314,7 +314,9 @@
   },
   "urlEditor": {
     "addParameter": "Add Parameter",
+    "credentialsNotSupported": "URLs with username or password are not supported.",
     "delete": "Delete",
+    "deleteParamAriaLabel": "Delete parameter row {{row}}",
     "generatedUrl": "Generated URL",
     "hash": "Fragment",
     "hashPlaceholder": "section",
@@ -325,6 +327,8 @@
     "key": "Key",
     "noParameters": "No query parameters",
     "parseButton": "Parse URL",
+    "paramKeyAriaLabel": "Parameter key, row {{row}}",
+    "paramValueAriaLabel": "Parameter value, row {{row}}",
     "path": "Path",
     "pathPlaceholder": "search",
     "protocol": "Protocol",

--- a/public/locales/en/string.json
+++ b/public/locales/en/string.json
@@ -334,9 +334,9 @@
     "protocol": "Protocol",
     "queryParameters": "Query Parameters",
     "toolInfo": {
-      "description": "Paste a URL to inspect and edit its query parameters, then copy the updated link.",
-      "longDescription": "This tool parses a URL into its components and lets you edit the protocol, host, path, fragment, and query parameters visually. Add, remove, or change any part and the generated URL updates in real time. Everything runs in your browser with no server requests.",
-      "shortDescription": "Inspect and edit URL query parameters.",
+      "description": "Paste a URL and click \"Parse URL\" to inspect and edit its components.",
+      "longDescription": "This tool parses a URL into its components and lets you edit the protocol, host, path, fragment, and query parameters visually. After changing the input URL, click \"Parse URL\" again to refresh the parsed details. You can add, remove, or modify any part and copy the generated URL. No server requests.",
+      "shortDescription": "Inspect and edit URL components and query parameters.",
       "title": "URL Editor"
     },
     "urlDetails": "URL Details",

--- a/src/pages/tools/string/index.ts
+++ b/src/pages/tools/string/index.ts
@@ -22,6 +22,7 @@ import { tool as stringCensor } from './censor/meta';
 import { tool as stringPasswordGenerator } from './password-generator/meta';
 import { tool as stringEncodeUrl } from './url-encode/meta';
 import { tool as stringDecodeUrl } from './url-decode/meta';
+import { tool as stringUrlEditor } from './url-editor/meta';
 import { tool as stringCompare } from './text-compare/meta';
 import { tool as stringUnicode } from './unicode/meta';
 
@@ -48,6 +49,7 @@ export const stringTools = [
   stringPasswordGenerator,
   stringEncodeUrl,
   stringDecodeUrl,
+  stringUrlEditor,
   stringUnicode,
   stringHiddenCharacterDetector,
   stringCompare,

--- a/src/pages/tools/string/url-editor/UrlDetailsEditor.tsx
+++ b/src/pages/tools/string/url-editor/UrlDetailsEditor.tsx
@@ -1,0 +1,129 @@
+import {
+  Box,
+  FormControl,
+  Grid,
+  InputAdornment,
+  InputLabel,
+  MenuItem,
+  Select,
+  TextField
+} from '@mui/material';
+import { ParsedUrl } from './types';
+
+const PROTOCOLS = ['https:', 'http:'] as const;
+
+export type UrlDetailField = keyof Omit<ParsedUrl, 'params'>;
+
+type UrlDetailsEditorProps = {
+  value: ParsedUrl;
+  onChange: (field: UrlDetailField, value: string) => void;
+  labels: {
+    protocol: string;
+    host: string;
+    path: string;
+    hash: string;
+    hostPlaceholder: string;
+    pathPlaceholder: string;
+    hashPlaceholder: string;
+  };
+};
+
+export default function UrlDetailsEditor({
+  value,
+  onChange,
+  labels
+}: UrlDetailsEditorProps) {
+  const hashValue = value.hash.replace(/^#/, '');
+
+  return (
+    <Box
+      sx={{
+        border: 1,
+        borderRadius: 2,
+        borderColor: 'divider',
+        bgcolor: 'background.paper',
+        p: 2
+      }}
+    >
+      <Grid container spacing={2}>
+        <Grid item xs={12} sm={4} md={3}>
+          <FormControl fullWidth size="small">
+            <InputLabel id="url-editor-protocol">{labels.protocol}</InputLabel>
+            <Select
+              labelId="url-editor-protocol"
+              label={labels.protocol}
+              value={
+                PROTOCOLS.includes(value.protocol as (typeof PROTOCOLS)[number])
+                  ? value.protocol
+                  : 'https:'
+              }
+              onChange={(event) => onChange('protocol', event.target.value)}
+            >
+              {PROTOCOLS.map((protocol) => (
+                <MenuItem key={protocol} value={protocol}>
+                  {protocol.replace(':', '')}
+                </MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+        </Grid>
+
+        <Grid item xs={12} sm={8} md={9}>
+          <TextField
+            size="small"
+            fullWidth
+            label={labels.host}
+            placeholder={labels.hostPlaceholder}
+            value={value.host}
+            onChange={(event) => onChange('host', event.target.value)}
+            InputProps={{
+              startAdornment: (
+                <InputAdornment position="start">://</InputAdornment>
+              )
+            }}
+          />
+        </Grid>
+
+        <Grid item xs={12}>
+          <TextField
+            size="small"
+            fullWidth
+            label={labels.path}
+            placeholder={labels.pathPlaceholder}
+            value={value.pathname.replace(/^\//, '')}
+            onChange={(event) => {
+              const next = event.target.value.replace(/^\//, '');
+              onChange('pathname', next ? `/${next}` : '/');
+            }}
+            InputProps={{
+              startAdornment: (
+                <InputAdornment position="start">/</InputAdornment>
+              )
+            }}
+            inputProps={{ sx: { pl: 0.5 } }}
+          />
+        </Grid>
+
+        <Grid item xs={12}>
+          <TextField
+            size="small"
+            fullWidth
+            label={labels.hash}
+            placeholder={labels.hashPlaceholder}
+            value={hashValue}
+            onChange={(event) => {
+              const next = event.target.value.replace(/^#/, '');
+              onChange('hash', next ? `#${next}` : '');
+            }}
+            InputProps={{
+              startAdornment: (
+                <InputAdornment position="start">#</InputAdornment>
+              )
+            }}
+            inputProps={{ sx: { pl: 0.5 } }}
+          />
+        </Grid>
+      </Grid>
+    </Box>
+  );
+}

--- a/src/pages/tools/string/url-editor/UrlDetailsEditor.tsx
+++ b/src/pages/tools/string/url-editor/UrlDetailsEditor.tsx
@@ -1,3 +1,4 @@
+import { useId } from 'react';
 import {
   Box,
   FormControl,
@@ -33,6 +34,7 @@ export default function UrlDetailsEditor({
   onChange,
   labels
 }: UrlDetailsEditorProps) {
+  const protocolLabelId = useId();
   const hashValue = value.hash.replace(/^#/, '');
 
   return (
@@ -48,9 +50,9 @@ export default function UrlDetailsEditor({
       <Grid container spacing={2}>
         <Grid item xs={12} sm={4} md={3}>
           <FormControl fullWidth size="small">
-            <InputLabel id="url-editor-protocol">{labels.protocol}</InputLabel>
+            <InputLabel id={protocolLabelId}>{labels.protocol}</InputLabel>
             <Select
-              labelId="url-editor-protocol"
+              labelId={protocolLabelId}
               label={labels.protocol}
               value={
                 PROTOCOLS.includes(value.protocol as (typeof PROTOCOLS)[number])

--- a/src/pages/tools/string/url-editor/UrlDetailsEditor.tsx
+++ b/src/pages/tools/string/url-editor/UrlDetailsEditor.tsx
@@ -1,4 +1,4 @@
-import { useId } from 'react';
+import { useId, useMemo } from 'react';
 import {
   Box,
   FormControl,
@@ -9,15 +9,23 @@ import {
   Select,
   TextField
 } from '@mui/material';
-import { ParsedUrl } from './types';
+import { EditableUrlField, ParsedUrl } from './types';
 
 const PROTOCOLS = ['https:', 'http:'] as const;
 
-export type UrlDetailField = keyof Omit<ParsedUrl, 'params'>;
+export type { EditableUrlField as UrlDetailField };
+
+function getProtocolOptions(protocol: string): string[] {
+  if (PROTOCOLS.includes(protocol as (typeof PROTOCOLS)[number])) {
+    return [...PROTOCOLS];
+  }
+
+  return [protocol, ...PROTOCOLS];
+}
 
 type UrlDetailsEditorProps = {
   value: ParsedUrl;
-  onChange: (field: UrlDetailField, value: string) => void;
+  onChange: (field: EditableUrlField, value: string) => void;
   labels: {
     protocol: string;
     host: string;
@@ -36,6 +44,10 @@ export default function UrlDetailsEditor({
 }: UrlDetailsEditorProps) {
   const protocolLabelId = useId();
   const hashValue = value.hash.replace(/^#/, '');
+  const protocolOptions = useMemo(
+    () => getProtocolOptions(value.protocol),
+    [value.protocol]
+  );
 
   return (
     <Box
@@ -54,14 +66,10 @@ export default function UrlDetailsEditor({
             <Select
               labelId={protocolLabelId}
               label={labels.protocol}
-              value={
-                PROTOCOLS.includes(value.protocol as (typeof PROTOCOLS)[number])
-                  ? value.protocol
-                  : 'https:'
-              }
+              value={value.protocol}
               onChange={(event) => onChange('protocol', event.target.value)}
             >
-              {PROTOCOLS.map((protocol) => (
+              {protocolOptions.map((protocol) => (
                 <MenuItem key={protocol} value={protocol}>
                   {protocol.replace(':', '')}
                 </MenuItem>

--- a/src/pages/tools/string/url-editor/index.tsx
+++ b/src/pages/tools/string/url-editor/index.tsx
@@ -21,7 +21,12 @@ import InputHeader from '@components/InputHeader';
 import { ToolComponentProps } from '@tools/defineTool';
 import { useTranslation } from 'react-i18next';
 import UrlDetailsEditor, { UrlDetailField } from './UrlDetailsEditor';
-import { generateUrl, parseUrl } from './service';
+import {
+  createQueryParam,
+  generateUrl,
+  parseUrl,
+  URL_PARSE_ERRORS
+} from './service';
 import { ParsedUrl } from './types';
 
 const initialValues = {};
@@ -57,9 +62,16 @@ export default function UrlEditor({
     try {
       setParsedUrl(parseUrl(inputUrl));
       setParseError(null);
-    } catch {
+    } catch (error) {
       setParsedUrl(null);
-      setParseError(t('urlEditor.invalidUrl'));
+      if (
+        error instanceof Error &&
+        error.message === URL_PARSE_ERRORS.CREDENTIALS
+      ) {
+        setParseError(t('urlEditor.credentialsNotSupported'));
+      } else {
+        setParseError(t('urlEditor.invalidUrl'));
+      }
     }
   }, [inputUrl, t]);
 
@@ -75,29 +87,29 @@ export default function UrlEditor({
   const handleAddParam = useCallback(() => {
     setParsedUrl((current) =>
       current
-        ? { ...current, params: [...current.params, { key: '', value: '' }] }
+        ? { ...current, params: [...current.params, createQueryParam()] }
         : current
     );
   }, []);
 
-  const handleRemoveParam = useCallback((index: number) => {
+  const handleRemoveParam = useCallback((id: string) => {
     setParsedUrl((current) =>
       current
         ? {
             ...current,
-            params: current.params.filter((_, i) => i !== index)
+            params: current.params.filter((param) => param.id !== id)
           }
         : current
     );
   }, []);
 
   const handleParamChange = useCallback(
-    (index: number, field: 'key' | 'value', value: string) => {
+    (id: string, field: 'key' | 'value', value: string) => {
       setParsedUrl((current) => {
         if (!current) return current;
 
-        const params = current.params.map((param, i) =>
-          i === index ? { ...param, [field]: value } : param
+        const params = current.params.map((param) =>
+          param.id === id ? { ...param, [field]: value } : param
         );
 
         return { ...current, params };
@@ -166,19 +178,24 @@ export default function UrlEditor({
                     </TableHead>
                     <TableBody>
                       {parsedUrl.params.map((param, index) => (
-                        <TableRow key={index}>
+                        <TableRow key={param.id}>
                           <TableCell>
                             <TextField
                               value={param.key}
                               onChange={(event) =>
                                 handleParamChange(
-                                  index,
+                                  param.id,
                                   'key',
                                   event.target.value
                                 )
                               }
                               size="small"
                               fullWidth
+                              inputProps={{
+                                'aria-label': t('urlEditor.paramKeyAriaLabel', {
+                                  row: index + 1
+                                })
+                              }}
                             />
                           </TableCell>
                           <TableCell>
@@ -186,19 +203,27 @@ export default function UrlEditor({
                               value={param.value}
                               onChange={(event) =>
                                 handleParamChange(
-                                  index,
+                                  param.id,
                                   'value',
                                   event.target.value
                                 )
                               }
                               size="small"
                               fullWidth
+                              inputProps={{
+                                'aria-label': t(
+                                  'urlEditor.paramValueAriaLabel',
+                                  { row: index + 1 }
+                                )
+                              }}
                             />
                           </TableCell>
                           <TableCell align="center">
                             <IconButton
-                              aria-label={t('urlEditor.delete')}
-                              onClick={() => handleRemoveParam(index)}
+                              aria-label={t('urlEditor.deleteParamAriaLabel', {
+                                row: index + 1
+                              })}
+                              onClick={() => handleRemoveParam(param.id)}
                               size="small"
                             >
                               <DeleteIcon fontSize="small" />

--- a/src/pages/tools/string/url-editor/index.tsx
+++ b/src/pages/tools/string/url-editor/index.tsx
@@ -1,0 +1,246 @@
+import { useCallback, useEffect, useState } from 'react';
+import {
+  Alert,
+  Box,
+  Button,
+  IconButton,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableRow,
+  TextField,
+  Typography
+} from '@mui/material';
+import DeleteIcon from '@mui/icons-material/Delete';
+import AddIcon from '@mui/icons-material/Add';
+import ToolContent from '@components/ToolContent';
+import ToolTextInput from '@components/input/ToolTextInput';
+import ToolTextResult from '@components/result/ToolTextResult';
+import InputHeader from '@components/InputHeader';
+import { ToolComponentProps } from '@tools/defineTool';
+import { useTranslation } from 'react-i18next';
+import UrlDetailsEditor, { UrlDetailField } from './UrlDetailsEditor';
+import { generateUrl, parseUrl } from './service';
+import { ParsedUrl } from './types';
+
+const initialValues = {};
+
+export default function UrlEditor({
+  title,
+  longDescription
+}: ToolComponentProps) {
+  const { t } = useTranslation('string');
+  const [inputUrl, setInputUrl] = useState('');
+  const [parsedUrl, setParsedUrl] = useState<ParsedUrl | null>(null);
+  const [generatedUrl, setGeneratedUrl] = useState('');
+  const [parseError, setParseError] = useState<string | null>(null);
+  const [generateError, setGenerateError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!parsedUrl) {
+      setGeneratedUrl('');
+      setGenerateError(null);
+      return;
+    }
+
+    try {
+      setGeneratedUrl(generateUrl(parsedUrl));
+      setGenerateError(null);
+    } catch {
+      setGeneratedUrl('');
+      setGenerateError(t('urlEditor.invalidUrl'));
+    }
+  }, [parsedUrl, t]);
+
+  const handleParse = useCallback(() => {
+    try {
+      setParsedUrl(parseUrl(inputUrl));
+      setParseError(null);
+    } catch {
+      setParsedUrl(null);
+      setParseError(t('urlEditor.invalidUrl'));
+    }
+  }, [inputUrl, t]);
+
+  const handleFieldChange = useCallback(
+    (field: UrlDetailField, value: string) => {
+      setParsedUrl((current) =>
+        current ? { ...current, [field]: value } : current
+      );
+    },
+    []
+  );
+
+  const handleAddParam = useCallback(() => {
+    setParsedUrl((current) =>
+      current
+        ? { ...current, params: [...current.params, { key: '', value: '' }] }
+        : current
+    );
+  }, []);
+
+  const handleRemoveParam = useCallback((index: number) => {
+    setParsedUrl((current) =>
+      current
+        ? {
+            ...current,
+            params: current.params.filter((_, i) => i !== index)
+          }
+        : current
+    );
+  }, []);
+
+  const handleParamChange = useCallback(
+    (index: number, field: 'key' | 'value', value: string) => {
+      setParsedUrl((current) => {
+        if (!current) return current;
+
+        const params = current.params.map((param, i) =>
+          i === index ? { ...param, [field]: value } : param
+        );
+
+        return { ...current, params };
+      });
+    },
+    []
+  );
+
+  return (
+    <ToolContent
+      title={title}
+      initialValues={initialValues}
+      getGroups={null}
+      compute={() => {}}
+      input={inputUrl}
+      setInput={setInputUrl}
+      inputComponent={
+        <Box>
+          <ToolTextInput
+            title={t('urlEditor.inputTitle')}
+            value={inputUrl}
+            onChange={setInputUrl}
+            placeholder="https://example.com/search?q=test"
+          />
+          <Box mt={2}>
+            <Button variant="contained" onClick={handleParse}>
+              {t('urlEditor.parseButton')}
+            </Button>
+          </Box>
+
+          {parseError && (
+            <Alert severity="error" sx={{ mt: 2 }}>
+              {parseError}
+            </Alert>
+          )}
+
+          {parsedUrl && (
+            <Box mt={3}>
+              <InputHeader title={t('urlEditor.urlDetails')} />
+              <UrlDetailsEditor
+                value={parsedUrl}
+                onChange={handleFieldChange}
+                labels={{
+                  protocol: t('urlEditor.protocol'),
+                  host: t('urlEditor.host'),
+                  path: t('urlEditor.path'),
+                  hash: t('urlEditor.hash'),
+                  hostPlaceholder: t('urlEditor.hostPlaceholder'),
+                  pathPlaceholder: t('urlEditor.pathPlaceholder'),
+                  hashPlaceholder: t('urlEditor.hashPlaceholder')
+                }}
+              />
+
+              <Box mt={3}>
+                <InputHeader title={t('urlEditor.queryParameters')} />
+                {parsedUrl.params.length > 0 ? (
+                  <Table size="small">
+                    <TableHead>
+                      <TableRow>
+                        <TableCell>{t('urlEditor.key')}</TableCell>
+                        <TableCell>{t('urlEditor.value')}</TableCell>
+                        <TableCell width={80} align="center">
+                          {t('urlEditor.delete')}
+                        </TableCell>
+                      </TableRow>
+                    </TableHead>
+                    <TableBody>
+                      {parsedUrl.params.map((param, index) => (
+                        <TableRow key={index}>
+                          <TableCell>
+                            <TextField
+                              value={param.key}
+                              onChange={(event) =>
+                                handleParamChange(
+                                  index,
+                                  'key',
+                                  event.target.value
+                                )
+                              }
+                              size="small"
+                              fullWidth
+                            />
+                          </TableCell>
+                          <TableCell>
+                            <TextField
+                              value={param.value}
+                              onChange={(event) =>
+                                handleParamChange(
+                                  index,
+                                  'value',
+                                  event.target.value
+                                )
+                              }
+                              size="small"
+                              fullWidth
+                            />
+                          </TableCell>
+                          <TableCell align="center">
+                            <IconButton
+                              aria-label={t('urlEditor.delete')}
+                              onClick={() => handleRemoveParam(index)}
+                              size="small"
+                            >
+                              <DeleteIcon fontSize="small" />
+                            </IconButton>
+                          </TableCell>
+                        </TableRow>
+                      ))}
+                    </TableBody>
+                  </Table>
+                ) : (
+                  <Typography variant="body2" color="text.secondary">
+                    {t('urlEditor.noParameters')}
+                  </Typography>
+                )}
+                <Button
+                  startIcon={<AddIcon />}
+                  onClick={handleAddParam}
+                  sx={{ mt: 2 }}
+                >
+                  {t('urlEditor.addParameter')}
+                </Button>
+              </Box>
+
+              {generateError && (
+                <Alert severity="warning" sx={{ mt: 2 }}>
+                  {generateError}
+                </Alert>
+              )}
+            </Box>
+          )}
+        </Box>
+      }
+      resultComponent={
+        <ToolTextResult
+          title={t('urlEditor.generatedUrl')}
+          value={generatedUrl}
+        />
+      }
+      toolInfo={{
+        title: t('urlEditor.toolInfo.title', { title }),
+        description: longDescription
+      }}
+    />
+  );
+}

--- a/src/pages/tools/string/url-editor/index.tsx
+++ b/src/pages/tools/string/url-editor/index.tsx
@@ -30,6 +30,7 @@ import {
 import { ParsedUrl } from './types';
 
 const initialValues = {};
+const noop = () => {};
 
 export default function UrlEditor({
   title,
@@ -123,7 +124,7 @@ export default function UrlEditor({
       title={title}
       initialValues={initialValues}
       getGroups={null}
-      compute={() => {}}
+      compute={noop}
       input={inputUrl}
       setInput={setInputUrl}
       inputComponent={

--- a/src/pages/tools/string/url-editor/index.tsx
+++ b/src/pages/tools/string/url-editor/index.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useState } from 'react';
 import {
   Alert,
   Box,
@@ -39,25 +39,18 @@ export default function UrlEditor({
   const { t } = useTranslation('string');
   const [inputUrl, setInputUrl] = useState('');
   const [parsedUrl, setParsedUrl] = useState<ParsedUrl | null>(null);
-  const [generatedUrl, setGeneratedUrl] = useState('');
   const [parseError, setParseError] = useState<string | null>(null);
-  const [generateError, setGenerateError] = useState<string | null>(null);
 
-  useEffect(() => {
-    if (!parsedUrl) {
-      setGeneratedUrl('');
-      setGenerateError(null);
-      return;
-    }
+  let generatedUrl = '';
+  let generateError: string | null = null;
 
+  if (parsedUrl) {
     try {
-      setGeneratedUrl(generateUrl(parsedUrl));
-      setGenerateError(null);
+      generatedUrl = generateUrl(parsedUrl);
     } catch {
-      setGeneratedUrl('');
-      setGenerateError(t('urlEditor.invalidUrl'));
+      generateError = t('urlEditor.invalidUrl');
     }
-  }, [parsedUrl, t]);
+  }
 
   const handleParse = useCallback(() => {
     try {

--- a/src/pages/tools/string/url-editor/meta.ts
+++ b/src/pages/tools/string/url-editor/meta.ts
@@ -1,0 +1,25 @@
+import { defineTool } from '@tools/defineTool';
+import { lazy } from 'react';
+
+export const tool = defineTool('string', {
+  path: 'url-editor',
+  icon: 'mdi:link-edit',
+
+  keywords: [
+    'url',
+    'editor',
+    'query',
+    'parameters',
+    'parse',
+    'link',
+    'href',
+    'search params'
+  ],
+  component: lazy(() => import('./index')),
+  i18n: {
+    name: 'string:urlEditor.toolInfo.title',
+    description: 'string:urlEditor.toolInfo.description',
+    shortDescription: 'string:urlEditor.toolInfo.shortDescription',
+    longDescription: 'string:urlEditor.toolInfo.longDescription'
+  }
+});

--- a/src/pages/tools/string/url-editor/service.ts
+++ b/src/pages/tools/string/url-editor/service.ts
@@ -71,10 +71,14 @@ export function parseUrl(input: string): ParsedUrl {
 }
 
 export function generateUrl(parsed: ParsedUrl): string {
-  const protocol = parsed.protocol || 'https:';
+  const rawProtocol = parsed.protocol || 'https';
+  const protocol = rawProtocol.endsWith(':') ? rawProtocol : `${rawProtocol}:`;
   const host = parsed.host.trim();
   if (!host) {
     throw new Error(URL_PARSE_ERRORS.INVALID);
+  }
+  if (host.includes('@')) {
+    throw new Error(URL_PARSE_ERRORS.CREDENTIALS);
   }
 
   let pathname = parsed.pathname || '/';

--- a/src/pages/tools/string/url-editor/service.ts
+++ b/src/pages/tools/string/url-editor/service.ts
@@ -1,0 +1,56 @@
+import { ParsedUrl, QueryParam } from './types';
+
+export function parseUrl(input: string): ParsedUrl {
+  const trimmed = input.trim();
+  if (!trimmed) {
+    throw new Error('Invalid URL');
+  }
+
+  let url: URL;
+  try {
+    url = new URL(trimmed);
+  } catch {
+    throw new Error('Invalid URL');
+  }
+
+  const params: QueryParam[] = Array.from(url.searchParams.entries()).map(
+    ([key, value]) => ({ key, value })
+  );
+
+  return {
+    protocol: url.protocol,
+    host: url.host,
+    pathname: url.pathname,
+    hash: url.hash,
+    params
+  };
+}
+
+export function generateUrl(parsed: ParsedUrl): string {
+  const protocol = parsed.protocol || 'https:';
+  const host = parsed.host.trim();
+  if (!host) {
+    throw new Error('Invalid URL');
+  }
+
+  let pathname = parsed.pathname || '/';
+  if (!pathname.startsWith('/')) {
+    pathname = `/${pathname}`;
+  }
+
+  const url = new URL(`${protocol}//${host}${pathname}`);
+
+  let hash = parsed.hash.trim();
+  if (hash && !hash.startsWith('#')) {
+    hash = `#${hash}`;
+  }
+  url.hash = hash;
+
+  parsed.params.forEach(({ key, value }) => {
+    if (key) {
+      url.searchParams.append(key, value);
+    }
+  });
+
+  return url.toString();
+}

--- a/src/pages/tools/string/url-editor/service.ts
+++ b/src/pages/tools/string/url-editor/service.ts
@@ -5,8 +5,19 @@ export const URL_PARSE_ERRORS = {
   CREDENTIALS: 'URLs with credentials are not supported'
 } as const;
 
+let fallbackParamIdCounter = 0;
+
+function createParamId(): string {
+  if (globalThis.crypto?.randomUUID) {
+    return globalThis.crypto.randomUUID();
+  }
+
+  fallbackParamIdCounter += 1;
+  return `param-${fallbackParamIdCounter}-${Date.now()}`;
+}
+
 export function createQueryParam(key = '', value = ''): QueryParam {
-  return { id: crypto.randomUUID(), key, value };
+  return { id: createParamId(), key, value };
 }
 
 function detectOriginTrailingSlash(input: string, url: URL): boolean {
@@ -15,9 +26,17 @@ function detectOriginTrailingSlash(input: string, url: URL): boolean {
   }
 
   const beforeQueryOrHash = input.split(/[?#]/)[0];
-  const origin = `${url.protocol}//${url.host}`;
+  const schemeEnd = beforeQueryOrHash.indexOf('://');
+  if (schemeEnd === -1) {
+    return false;
+  }
 
-  return beforeQueryOrHash.slice(origin.length) === '/';
+  const firstSlashAfterScheme = beforeQueryOrHash.indexOf('/', schemeEnd + 3);
+  if (firstSlashAfterScheme === -1) {
+    return false;
+  }
+
+  return firstSlashAfterScheme === beforeQueryOrHash.length - 1;
 }
 
 export function parseUrl(input: string): ParsedUrl {

--- a/src/pages/tools/string/url-editor/service.ts
+++ b/src/pages/tools/string/url-editor/service.ts
@@ -1,20 +1,44 @@
 import { ParsedUrl, QueryParam } from './types';
 
+export const URL_PARSE_ERRORS = {
+  INVALID: 'Invalid URL',
+  CREDENTIALS: 'URLs with credentials are not supported'
+} as const;
+
+export function createQueryParam(key = '', value = ''): QueryParam {
+  return { id: crypto.randomUUID(), key, value };
+}
+
+function detectOriginTrailingSlash(input: string, url: URL): boolean {
+  if (url.pathname !== '/') {
+    return false;
+  }
+
+  const beforeQueryOrHash = input.split(/[?#]/)[0];
+  const origin = `${url.protocol}//${url.host}`;
+
+  return beforeQueryOrHash.slice(origin.length) === '/';
+}
+
 export function parseUrl(input: string): ParsedUrl {
   const trimmed = input.trim();
   if (!trimmed) {
-    throw new Error('Invalid URL');
+    throw new Error(URL_PARSE_ERRORS.INVALID);
   }
 
   let url: URL;
   try {
     url = new URL(trimmed);
   } catch {
-    throw new Error('Invalid URL');
+    throw new Error(URL_PARSE_ERRORS.INVALID);
+  }
+
+  if (url.username || url.password) {
+    throw new Error(URL_PARSE_ERRORS.CREDENTIALS);
   }
 
   const params: QueryParam[] = Array.from(url.searchParams.entries()).map(
-    ([key, value]) => ({ key, value })
+    ([key, value]) => createQueryParam(key, value)
   );
 
   return {
@@ -22,6 +46,7 @@ export function parseUrl(input: string): ParsedUrl {
     host: url.host,
     pathname: url.pathname,
     hash: url.hash,
+    originTrailingSlash: detectOriginTrailingSlash(trimmed, url),
     params
   };
 }
@@ -30,7 +55,7 @@ export function generateUrl(parsed: ParsedUrl): string {
   const protocol = parsed.protocol || 'https:';
   const host = parsed.host.trim();
   if (!host) {
-    throw new Error('Invalid URL');
+    throw new Error(URL_PARSE_ERRORS.INVALID);
   }
 
   let pathname = parsed.pathname || '/';
@@ -38,19 +63,30 @@ export function generateUrl(parsed: ParsedUrl): string {
     pathname = `/${pathname}`;
   }
 
-  const url = new URL(`${protocol}//${host}${pathname}`);
+  let base: string;
+  if (pathname === '/' && !parsed.originTrailingSlash) {
+    base = `${protocol}//${host}`;
+  } else if (pathname === '/') {
+    base = `${protocol}//${host}/`;
+  } else {
+    base = `${protocol}//${host}${pathname}`;
+  }
+
+  const searchParams = new URLSearchParams();
+  parsed.params.forEach(({ key, value }) => {
+    const trimmedKey = key.trim();
+    if (trimmedKey) {
+      searchParams.append(trimmedKey, value);
+    }
+  });
+
+  const search = searchParams.toString();
+  const query = search ? `?${search}` : '';
 
   let hash = parsed.hash.trim();
   if (hash && !hash.startsWith('#')) {
     hash = `#${hash}`;
   }
-  url.hash = hash;
 
-  parsed.params.forEach(({ key, value }) => {
-    if (key) {
-      url.searchParams.append(key, value);
-    }
-  });
-
-  return url.toString();
+  return `${base}${query}${hash}`;
 }

--- a/src/pages/tools/string/url-editor/service.ts
+++ b/src/pages/tools/string/url-editor/service.ts
@@ -77,7 +77,10 @@ export function generateUrl(parsed: ParsedUrl): string {
   if (!host) {
     throw new Error(URL_PARSE_ERRORS.INVALID);
   }
-  if (host.includes('@')) {
+
+  const checkUrl = new URL(`${protocol}//${host}`);
+
+  if (checkUrl.username || checkUrl.password) {
     throw new Error(URL_PARSE_ERRORS.CREDENTIALS);
   }
 

--- a/src/pages/tools/string/url-editor/types.ts
+++ b/src/pages/tools/string/url-editor/types.ts
@@ -1,4 +1,5 @@
 export interface QueryParam {
+  id: string;
   key: string;
   value: string;
 }
@@ -8,5 +9,7 @@ export interface ParsedUrl {
   host: string;
   pathname: string;
   hash: string;
+  /** True when the input used a trailing slash on an origin-only URL (e.g. https://example.com/) */
+  originTrailingSlash: boolean;
   params: QueryParam[];
 }

--- a/src/pages/tools/string/url-editor/types.ts
+++ b/src/pages/tools/string/url-editor/types.ts
@@ -1,3 +1,5 @@
+export type EditableUrlField = 'protocol' | 'host' | 'pathname' | 'hash';
+
 export interface QueryParam {
   id: string;
   key: string;

--- a/src/pages/tools/string/url-editor/types.ts
+++ b/src/pages/tools/string/url-editor/types.ts
@@ -1,0 +1,12 @@
+export interface QueryParam {
+  key: string;
+  value: string;
+}
+
+export interface ParsedUrl {
+  protocol: string;
+  host: string;
+  pathname: string;
+  hash: string;
+  params: QueryParam[];
+}

--- a/src/pages/tools/string/url-editor/url-editor.service.test.ts
+++ b/src/pages/tools/string/url-editor/url-editor.service.test.ts
@@ -41,6 +41,17 @@ describe('url-editor', () => {
     expect(parseUrl('https://example.com').originTrailingSlash).toBe(false);
   });
 
+  it('tracks trailing slash using input path, not normalized host', () => {
+    expect(parseUrl('https://example.com:443/').originTrailingSlash).toBe(true);
+    expect(parseUrl('https://example.com:443').originTrailingSlash).toBe(false);
+    expect(parseUrl('http://example.com:80/').originTrailingSlash).toBe(true);
+  });
+
+  it('preserves unsupported protocols in round-trip generation', () => {
+    const input = 'ftp://files.example.com/resource';
+    expect(generateUrl(parseUrl(input))).toBe(input);
+  });
+
   it('parses URLs with a hash', () => {
     const parsed = parseUrl('https://example.com/page#section1');
 
@@ -134,5 +145,18 @@ describe('url-editor', () => {
     parsed.host = '   ';
 
     expect(() => generateUrl(parsed)).toThrow(URL_PARSE_ERRORS.INVALID);
+  });
+
+  it('creates query param ids without randomUUID', () => {
+    const randomUUID = globalThis.crypto.randomUUID;
+    // @ts-expect-error test override
+    globalThis.crypto.randomUUID = undefined;
+
+    try {
+      const parsed = parseUrl('https://example.com?q=test');
+      expect(parsed.params[0]?.id).toMatch(/^param-\d+-\d+$/);
+    } finally {
+      globalThis.crypto.randomUUID = randomUUID;
+    }
   });
 });

--- a/src/pages/tools/string/url-editor/url-editor.service.test.ts
+++ b/src/pages/tools/string/url-editor/url-editor.service.test.ts
@@ -1,22 +1,27 @@
 import { describe, expect, it } from 'vitest';
-import { generateUrl, parseUrl } from './service';
+import { generateUrl, parseUrl, URL_PARSE_ERRORS } from './service';
+
+function paramEntries(parsed: ReturnType<typeof parseUrl>) {
+  return parsed.params.map(({ key, value }) => ({ key, value }));
+}
 
 describe('url-editor', () => {
   it('parses a valid URL with query parameters', () => {
-    expect(parseUrl('https://example.com/search?q=iphone&page=2')).toEqual({
-      protocol: 'https:',
-      host: 'example.com',
-      pathname: '/search',
-      hash: '',
-      params: [
-        { key: 'q', value: 'iphone' },
-        { key: 'page', value: '2' }
-      ]
-    });
+    const parsed = parseUrl('https://example.com/search?q=iphone&page=2');
+
+    expect(parsed.protocol).toBe('https:');
+    expect(parsed.host).toBe('example.com');
+    expect(parsed.pathname).toBe('/search');
+    expect(parsed.hash).toBe('');
+    expect(parsed.originTrailingSlash).toBe(false);
+    expect(paramEntries(parsed)).toEqual([
+      { key: 'q', value: 'iphone' },
+      { key: 'page', value: '2' }
+    ]);
   });
 
   it('parses multiple query parameters', () => {
-    expect(parseUrl('https://example.com?a=1&b=2&c=3').params).toEqual([
+    expect(paramEntries(parseUrl('https://example.com?a=1&b=2&c=3'))).toEqual([
       { key: 'a', value: '1' },
       { key: 'b', value: '2' },
       { key: 'c', value: '3' }
@@ -24,39 +29,63 @@ describe('url-editor', () => {
   });
 
   it('parses URLs without query parameters', () => {
-    expect(parseUrl('https://example.com')).toEqual({
-      protocol: 'https:',
-      host: 'example.com',
-      pathname: '/',
-      hash: '',
-      params: []
-    });
+    const parsed = parseUrl('https://example.com');
+
+    expect(parsed.pathname).toBe('/');
+    expect(parsed.originTrailingSlash).toBe(false);
+    expect(parsed.params).toEqual([]);
+  });
+
+  it('tracks trailing slash on origin-only URLs', () => {
+    expect(parseUrl('https://example.com/').originTrailingSlash).toBe(true);
+    expect(parseUrl('https://example.com').originTrailingSlash).toBe(false);
   });
 
   it('parses URLs with a hash', () => {
-    expect(parseUrl('https://example.com/page#section1')).toEqual({
-      protocol: 'https:',
-      host: 'example.com',
-      pathname: '/page',
-      hash: '#section1',
-      params: []
-    });
+    const parsed = parseUrl('https://example.com/page#section1');
+
+    expect(parsed.pathname).toBe('/page');
+    expect(parsed.hash).toBe('#section1');
+    expect(parsed.originTrailingSlash).toBe(false);
   });
 
   it('throws for invalid URLs', () => {
-    expect(() => parseUrl('abc123')).toThrow('Invalid URL');
-    expect(() => parseUrl('')).toThrow('Invalid URL');
+    expect(() => parseUrl('abc123')).toThrow(URL_PARSE_ERRORS.INVALID);
+    expect(() => parseUrl('')).toThrow(URL_PARSE_ERRORS.INVALID);
+  });
+
+  it('rejects URLs with credentials', () => {
+    expect(() => parseUrl('https://user:pass@example.com/')).toThrow(
+      URL_PARSE_ERRORS.CREDENTIALS
+    );
   });
 
   it('generates an updated URL from parsed components', () => {
     const parsed = parseUrl('https://example.com/search?q=iphone&page=2');
-    parsed.params = [
-      { key: 'q', value: 'samsung' },
-      { key: 'page', value: '5' }
-    ];
+    parsed.params = parsed.params.map((param, index) =>
+      index === 0 ? { ...param, value: 'samsung' } : { ...param, value: '5' }
+    );
 
     expect(generateUrl(parsed)).toBe(
       'https://example.com/search?q=samsung&page=5'
+    );
+  });
+
+  it('preserves origin-only URLs without a trailing slash', () => {
+    expect(generateUrl(parseUrl('https://example.com'))).toBe(
+      'https://example.com'
+    );
+  });
+
+  it('preserves origin-only URLs with a trailing slash', () => {
+    expect(generateUrl(parseUrl('https://example.com/'))).toBe(
+      'https://example.com/'
+    );
+  });
+
+  it('preserves hash on origin-only URLs without inserting a slash', () => {
+    expect(generateUrl(parseUrl('https://example.com#top'))).toBe(
+      'https://example.com#top'
     );
   });
 
@@ -89,10 +118,21 @@ describe('url-editor', () => {
     expect(generateUrl(parsed)).toBe('https://example.com/page#section1');
   });
 
+  it('ignores whitespace-only query keys', () => {
+    const parsed = parseUrl('https://example.com?q=test');
+    parsed.params.push({
+      id: 'temp-id',
+      key: '   ',
+      value: 'ignored'
+    });
+
+    expect(generateUrl(parsed)).toBe('https://example.com?q=test');
+  });
+
   it('throws when host is empty', () => {
     const parsed = parseUrl('https://example.com');
     parsed.host = '   ';
 
-    expect(() => generateUrl(parsed)).toThrow('Invalid URL');
+    expect(() => generateUrl(parsed)).toThrow(URL_PARSE_ERRORS.INVALID);
   });
 });

--- a/src/pages/tools/string/url-editor/url-editor.service.test.ts
+++ b/src/pages/tools/string/url-editor/url-editor.service.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { generateUrl, parseUrl, URL_PARSE_ERRORS } from './service';
 
 function paramEntries(parsed: ReturnType<typeof parseUrl>) {
@@ -147,16 +147,21 @@ describe('url-editor', () => {
     expect(() => generateUrl(parsed)).toThrow(URL_PARSE_ERRORS.INVALID);
   });
 
+  it('throws when host contains credentials', () => {
+    const parsed = parseUrl('https://example.com');
+    parsed.host = 'user:pass@example.com';
+
+    expect(() => generateUrl(parsed)).toThrow(URL_PARSE_ERRORS.CREDENTIALS);
+  });
+
   it('creates query param ids without randomUUID', () => {
-    const randomUUID = globalThis.crypto.randomUUID;
-    // @ts-expect-error test override
-    globalThis.crypto.randomUUID = undefined;
+    vi.stubGlobal('crypto', { randomUUID: undefined });
 
     try {
       const parsed = parseUrl('https://example.com?q=test');
       expect(parsed.params[0]?.id).toMatch(/^param-\d+-\d+$/);
     } finally {
-      globalThis.crypto.randomUUID = randomUUID;
+      vi.unstubAllGlobals();
     }
   });
 });

--- a/src/pages/tools/string/url-editor/url-editor.service.test.ts
+++ b/src/pages/tools/string/url-editor/url-editor.service.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from 'vitest';
+import { generateUrl, parseUrl } from './service';
+
+describe('url-editor', () => {
+  it('parses a valid URL with query parameters', () => {
+    expect(parseUrl('https://example.com/search?q=iphone&page=2')).toEqual({
+      protocol: 'https:',
+      host: 'example.com',
+      pathname: '/search',
+      hash: '',
+      params: [
+        { key: 'q', value: 'iphone' },
+        { key: 'page', value: '2' }
+      ]
+    });
+  });
+
+  it('parses multiple query parameters', () => {
+    expect(parseUrl('https://example.com?a=1&b=2&c=3').params).toEqual([
+      { key: 'a', value: '1' },
+      { key: 'b', value: '2' },
+      { key: 'c', value: '3' }
+    ]);
+  });
+
+  it('parses URLs without query parameters', () => {
+    expect(parseUrl('https://example.com')).toEqual({
+      protocol: 'https:',
+      host: 'example.com',
+      pathname: '/',
+      hash: '',
+      params: []
+    });
+  });
+
+  it('parses URLs with a hash', () => {
+    expect(parseUrl('https://example.com/page#section1')).toEqual({
+      protocol: 'https:',
+      host: 'example.com',
+      pathname: '/page',
+      hash: '#section1',
+      params: []
+    });
+  });
+
+  it('throws for invalid URLs', () => {
+    expect(() => parseUrl('abc123')).toThrow('Invalid URL');
+    expect(() => parseUrl('')).toThrow('Invalid URL');
+  });
+
+  it('generates an updated URL from parsed components', () => {
+    const parsed = parseUrl('https://example.com/search?q=iphone&page=2');
+    parsed.params = [
+      { key: 'q', value: 'samsung' },
+      { key: 'page', value: '5' }
+    ];
+
+    expect(generateUrl(parsed)).toBe(
+      'https://example.com/search?q=samsung&page=5'
+    );
+  });
+
+  it('round-trips URL components', () => {
+    const input = 'https://example.com/search?q=test&sort=desc#top';
+    expect(generateUrl(parseUrl(input))).toBe(input);
+  });
+
+  it('generates URL with edited host and path', () => {
+    const parsed = parseUrl('https://example.com/search?q=test');
+    parsed.host = 'github.com';
+    parsed.pathname = '/topics/open-source';
+
+    expect(generateUrl(parsed)).toBe(
+      'https://github.com/topics/open-source?q=test'
+    );
+  });
+
+  it('normalizes path without a leading slash', () => {
+    const parsed = parseUrl('https://example.com/search');
+    parsed.pathname = 'topics/open-source';
+
+    expect(generateUrl(parsed)).toBe('https://example.com/topics/open-source');
+  });
+
+  it('normalizes hash without a leading hash symbol', () => {
+    const parsed = parseUrl('https://example.com/page');
+    parsed.hash = 'section1';
+
+    expect(generateUrl(parsed)).toBe('https://example.com/page#section1');
+  });
+
+  it('throws when host is empty', () => {
+    const parsed = parseUrl('https://example.com');
+    parsed.host = '   ';
+
+    expect(() => generateUrl(parsed)).toThrow('Invalid URL');
+  });
+});


### PR DESCRIPTION
For the issue #384 asking for a URL editor tool
Summary:
Adds a new URL editor tool under the String category.

Features : 
* Parse URLs into protocol, host, path, fragment, and query parameters
* Edit protocol, host, path, and fragment
* Add, edit, and remove query parameters
* Real-time URL generation
* Copy generated URL
* Validation for invalid URLs and empty hosts

Implementation:
* Added a dedicated URL Editor tool
* Separated UI, business logic, and types
* Added English translations
* Registered the tool in the String tools category

Tests:
Added service tests covering:
* URL parsing
* URL generation
* Host/path editing
* Path/hash normalization
* Invalid URL handling
* Empty host handling
* Round-trip parse/generate consistency

All tests pass successfully.

Closes #384
