### PR TITLE
fix: validate list shuffle regex separators

### DIFF
--- a/src/pages/tools/list/shuffle/service.ts
+++ b/src/pages/tools/list/shuffle/service.ts
@@ -1,5 +1,21 @@
 export type SplitOperatorType = 'symbol' | 'regex';
 
+const MAX_REGEX_SEPARATOR_LENGTH = 100;
+const NESTED_QUANTIFIER_PATTERN =
+  /\((?:[^()\\]|\\.)*[+*](?:[^()\\]|\\.)*\)[+*?{]/;
+
+function createSplitRegex(pattern: string): RegExp {
+  if (pattern.length > MAX_REGEX_SEPARATOR_LENGTH) {
+    throw new Error(
+      `Regex pattern is too long (max ${MAX_REGEX_SEPARATOR_LENGTH} characters).`
+    );
+  }
+  if (NESTED_QUANTIFIER_PATTERN.test(pattern)) {
+    throw new Error('Regex pattern is too complex.');
+  }
+  return new RegExp(pattern);
+}
+
 // function that randomize the array
 function shuffleArray(array: string[]): string[] {
   const shuffledArray = array.slice(); // Create a copy of the array
@@ -24,7 +40,7 @@ export function shuffleList(
       array = input.split(splitSeparator);
       break;
     case 'regex':
-      array = input.split(new RegExp(splitSeparator));
+      array = input.split(createSplitRegex(splitSeparator));
       break;
   }
   shuffledArray = shuffleArray(array);

--- a/src/pages/tools/list/shuffle/shuffle.service.test.ts
+++ b/src/pages/tools/list/shuffle/shuffle.service.test.ts
@@ -82,4 +82,28 @@ describe('shuffle function', () => {
     );
     expect(result).toBe('');
   });
+
+  it('should split using a valid regex separator', () => {
+    const result = shuffleList('regex', 'apple,banana;orange', '[,;]', ' ');
+
+    expect(result.split(' ').sort()).toEqual(['apple', 'banana', 'orange']);
+  });
+
+  it('should reject regex separators that are too long', () => {
+    expect(() => shuffleList('regex', 'a,b,c', 'a'.repeat(101), ' ')).toThrow(
+      /Regex pattern is too long/
+    );
+  });
+
+  it('should reject nested quantified regex separators', () => {
+    expect(() =>
+      shuffleList('regex', 'aaaaaaaaaaaaaaaaaaaaab', '(a+)+$', ' ')
+    ).toThrow(/Regex pattern is too complex/);
+  });
+
+  it('should reject invalid regex separators', () => {
+    expect(() => shuffleList('regex', 'a,b,c', '[', ' ')).toThrow(
+      /Invalid regular expression/
+    );
+  });
 });


### PR DESCRIPTION
## Summary
- validate List Shuffle regex separators before constructing RegExp
- reject overly long regex separators
- reject nested quantified patterns such as (a+)+$ that can trigger catastrophic backtracking
- add regression tests for valid regex separators and rejected unsafe patterns

Fixes #377

## Testing
- npx vitest run src/pages/tools/list/shuffle/shuffle.service.test.ts