### PR TITLE
fix: validate JSON-to-XML tag names and nesting depth

### DIFF
--- a/public/locales/en/json.json
+++ b/public/locales/en/json.json
@@ -37,7 +37,21 @@
   "jsonToXml": {
     "description": "Convert JSON data to XML format. Transform structured JSON objects into well-formed XML documents.",
     "shortDescription": "Convert JSON to XML format",
-    "title": "JSON to XML"
+    "title": "JSON to XML",
+    "inputTitle": "Input JSON",
+    "outputTitle": "Output XML",
+    "options": {
+      "indentationTitle": "Indentation Options",
+      "useSpaceTitle": "Use Spaces for indentation",
+      "useSpaceDesc": "Use spaces to visualize the hierarchical structure of XML.",
+      "useTabTitle": "Use Tabs for indentation",
+      "useTabDesc": "Use tabs to visualize the hierarchical structure of XML.",
+      "noIdentTitle": "No indentation",
+      "noIdentDesc": "Output XML without any indentation.",
+      "metaInfoTitle": "XML Meta Information",
+      "addMetaTagTitle": "Add an XML Meta Tag",
+      "addMetaTagDesc": "Add a meta tag at the beginning of the XML output"
+    }
   },
   "minify": {
     "description": "Remove all unnecessary whitespace from JSON.",

--- a/src/pages/tools/json/json-to-xml/index.tsx
+++ b/src/pages/tools/json/json-to-xml/index.tsx
@@ -8,11 +8,8 @@ import { ToolComponentProps } from '@tools/defineTool';
 import { Box } from '@mui/material';
 import CheckboxWithDesc from '@components/options/CheckboxWithDesc';
 import SimpleRadio from '@components/options/SimpleRadio';
-
-type InitialValuesType = {
-  indentationType: 'space' | 'tab' | 'none';
-  addMetaTag: boolean;
-};
+import { InitialValuesType } from './types';
+import { useTranslation } from 'react-i18next';
 
 const initialValues: InitialValuesType = {
   indentationType: 'space',
@@ -57,6 +54,7 @@ const exampleCards: CardExampleType<InitialValuesType>[] = [
 ];
 
 export default function JsonToXml({ title }: ToolComponentProps) {
+  const { t } = useTranslation('json');
   const [input, setInput] = useState<string>('');
   const [result, setResult] = useState<string>('');
 
@@ -85,14 +83,18 @@ export default function JsonToXml({ title }: ToolComponentProps) {
       exampleCards={exampleCards}
       inputComponent={
         <ToolCodeInput
-          title="Input Json"
+          title={t('jsonToXml.inputTitle')}
           value={input}
           onChange={setInput}
           language="json"
         />
       }
       resultComponent={
-        <ToolTextResult title="Output XML" value={result} extension={'xml'} />
+        <ToolTextResult
+          title={t('jsonToXml.outputTitle')}
+          value={result}
+          extension={'xml'}
+        />
       }
       getGroups={({ values, updateField }) => [
         {
@@ -101,38 +103,34 @@ export default function JsonToXml({ title }: ToolComponentProps) {
             <Box>
               <SimpleRadio
                 checked={values.indentationType === 'space'}
-                title={'Use Spaces for indentation'}
-                description={
-                  'Use spaces to visualize the hierarchical structure of XML.'
-                }
+                title={t('jsonToXml.options.useSpaceTitle')}
+                description={t('jsonToXml.options.useSpaceDesc')}
                 onClick={() => updateField('indentationType', 'space')}
               />
               <SimpleRadio
                 checked={values.indentationType === 'tab'}
-                title={'Use Tabs for indentation'}
-                description={
-                  'Use tabs to visualize the hierarchical structure of XML.'
-                }
+                title={t('jsonToXml.options.useTabTitle')}
+                description={t('jsonToXml.options.useTabDesc')}
                 onClick={() => updateField('indentationType', 'tab')}
               />
               <SimpleRadio
                 checked={values.indentationType === 'none'}
-                title={'No indentation'}
-                description={'Output XML without any indentation.'}
+                title={t('jsonToXml.options.noIdentTitle')}
+                description={t('jsonToXml.options.noIdentDesc')}
                 onClick={() => updateField('indentationType', 'none')}
               />
             </Box>
           )
         },
         {
-          title: 'XML Meta Information',
+          title: t('jsonToXml.options.metaInfoTitle'),
           component: (
             <Box>
               <CheckboxWithDesc
                 checked={values.addMetaTag}
                 onChange={(value) => updateField('addMetaTag', value)}
-                title="Add an XML Meta Tag"
-                description="Add a meta tag at the beginning of the XML output."
+                title={t('jsonToXml.options.addMetaTagTitle')}
+                description={t('jsonToXml.options.addMetaTagDesc')}
               />
             </Box>
           )

--- a/src/pages/tools/json/json-to-xml/service.test.ts
+++ b/src/pages/tools/json/json-to-xml/service.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+import { convertJsonToXml } from './service';
+
+const defaultOptions: Parameters<typeof convertJsonToXml>[1] = {
+  indentationType: 'none',
+  addMetaTag: false
+};
+
+describe('convertJsonToXml', () => {
+  it('converts basic objects to XML', () => {
+    const result = convertJsonToXml(
+      JSON.stringify({ name: 'Alice', active: true }),
+      defaultOptions
+    );
+
+    expect(result).toBe('<root><name>Alice</name><active>true</active></root>');
+  });
+
+  it('normalizes JSON keys into valid XML tag names', () => {
+    const result = convertJsonToXml(
+      JSON.stringify({
+        'hello world': 'value',
+        '1st place': 'gold',
+        'a<b': 'xss',
+        '': 'empty'
+      }),
+      defaultOptions
+    );
+
+    expect(result).toBe(
+      '<root><hello_world>value</hello_world><_1st_place>gold</_1st_place><a_b>xss</a_b><_>empty</_></root>'
+    );
+  });
+
+  it('guards against excessive JSON nesting', () => {
+    const input = JSON.stringify(createNestedObject(101));
+
+    expect(() => convertJsonToXml(input, defaultOptions)).toThrow(
+      'JSON nesting exceeds maximum depth of 100.'
+    );
+  });
+});
+
+const createNestedObject = (depth: number): object => {
+  let current: Record<string, unknown> = { value: 'end' };
+
+  for (let index = 0; index < depth; index += 1) {
+    current = { item: current };
+  }
+
+  return current;
+};

--- a/src/pages/tools/json/json-to-xml/service.ts
+++ b/src/pages/tools/json/json-to-xml/service.ts
@@ -1,102 +1,132 @@
-type JsonToXmlOptions = {
-  indentationType: 'space' | 'tab' | 'none';
-  addMetaTag: boolean;
-};
+import { InitialValuesType } from './types';
 
-const MAX_XML_DEPTH = 100;
+type JsonObject = Record<string, any>;
+
+const MAX_JSON_DEPTH = 100;
 
 export const convertJsonToXml = (
   json: string,
-  options: JsonToXmlOptions
+  options: InitialValuesType
 ): string => {
-  const obj = JSON.parse(json);
-  return convertObjectToXml(obj, options);
+  const parsed = JSON.parse(json);
+
+  if (typeof parsed !== 'object' || parsed === null) {
+    throw new Error('JSON root value must be an object or array.');
+  }
+
+  const chunks: string[] = [];
+  const newline = options.indentationType === 'none' ? '' : '\n';
+
+  if (options.addMetaTag) {
+    chunks.push(`<?xml version="1.0" encoding="UTF-8"?>${newline}`);
+  }
+
+  chunks.push(`<root>${newline}`);
+
+  if (Array.isArray(parsed)) {
+    parsed.forEach((item) => {
+      chunks.push(convertArrayItemToXml(item, options, 1));
+    });
+  } else {
+    chunks.push(convertObjectToXml(parsed, options, 1));
+  }
+
+  chunks.push('</root>');
+
+  return chunks.join('');
 };
 
-const getIndentation = (options: JsonToXmlOptions, depth: number): string => {
+const convertArrayItemToXml = (
+  item: any,
+  options: InitialValuesType,
+  depth: number
+): string => {
+  const indentation = getIndentation(options, depth);
+  const newline = options.indentationType === 'none' ? '' : '\n';
+
+  if (typeof item === 'object' && item !== null && !Array.isArray(item)) {
+    return `${indentation}<item>${newline}${convertObjectToXml(
+      item,
+      options,
+      depth + 1
+    )}${indentation}</item>${newline}`;
+  }
+
+  return `${indentation}<item>${escapeXml(String(item))}</item>${newline}`;
+};
+
+const convertObjectToXml = (
+  obj: JsonObject,
+  options: InitialValuesType,
+  depth: number
+): string => {
+  if (depth > MAX_JSON_DEPTH) {
+    throw new Error(`JSON nesting exceeds maximum depth of ${MAX_JSON_DEPTH}.`);
+  }
+
+  const chunks: string[] = [];
+  const newline = options.indentationType === 'none' ? '' : '\n';
+
+  for (const [key, value] of Object.entries(obj)) {
+    const tagName = normalizeXmlTagName(key);
+    const indentation = getIndentation(options, depth);
+
+    if (value === null) {
+      chunks.push(`${indentation}<${tagName}></${tagName}>${newline}`);
+      continue;
+    }
+
+    if (Array.isArray(value)) {
+      value.forEach((item) => {
+        chunks.push(`${indentation}<${tagName}>`);
+
+        if (typeof item === 'object' && item !== null && !Array.isArray(item)) {
+          chunks.push(newline);
+          chunks.push(convertObjectToXml(item, options, depth + 1));
+          chunks.push(indentation);
+        } else {
+          chunks.push(escapeXml(String(item)));
+        }
+
+        chunks.push(`</${tagName}>${newline}`);
+      });
+
+      continue;
+    }
+
+    if (typeof value === 'object') {
+      chunks.push(`${indentation}<${tagName}>${newline}`);
+
+      chunks.push(convertObjectToXml(value, options, depth + 1));
+
+      chunks.push(`${indentation}</${tagName}>${newline}`);
+
+      continue;
+    }
+
+    chunks.push(
+      `${indentation}<${tagName}>${escapeXml(
+        String(value)
+      )}</${tagName}>${newline}`
+    );
+  }
+
+  return chunks.join('');
+};
+
+const getIndentation = (options: InitialValuesType, depth: number): string => {
   switch (options.indentationType) {
     case 'space':
-      return '  '.repeat(depth + 1);
+      return '  '.repeat(depth);
     case 'tab':
-      return '\t'.repeat(depth + 1);
-    case 'none':
+      return '\t'.repeat(depth);
     default:
       return '';
   }
 };
 
-const convertObjectToXml = (
-  obj: any,
-  options: JsonToXmlOptions,
-  depth: number = 0
-): string => {
-  if (depth > MAX_XML_DEPTH) {
-    throw new Error(`JSON nesting exceeds maximum depth of ${MAX_XML_DEPTH}.`);
-  }
-
-  let xml = '';
-
-  const newline = options.indentationType === 'none' ? '' : '\n';
-
-  if (depth === 0) {
-    if (options.addMetaTag) {
-      xml += '<?xml version="1.0" encoding="UTF-8"?>' + newline;
-    }
-    xml += '<root>' + newline;
-  }
-
-  for (const key in obj) {
-    const value = obj[key];
-    const keyString = normalizeXmlTagName(key);
-
-    // Handle null values
-    if (value === null) {
-      xml += `${getIndentation(
-        options,
-        depth
-      )}<${keyString}></${keyString}>${newline}`;
-      continue;
-    }
-
-    // Handle arrays
-    if (Array.isArray(value)) {
-      value.forEach((item) => {
-        xml += `${getIndentation(options, depth)}<${keyString}>`;
-        if (item === null) {
-          xml += `</${keyString}>${newline}`;
-        } else if (typeof item === 'object') {
-          xml += `${newline}${convertObjectToXml(
-            item,
-            options,
-            depth + 1
-          )}${getIndentation(options, depth)}`;
-          xml += `</${keyString}>${newline}`;
-        } else {
-          xml += `${escapeXml(String(item))}</${keyString}>${newline}`;
-        }
-      });
-      continue;
-    }
-
-    // Handle objects
-    if (typeof value === 'object') {
-      xml += `${getIndentation(options, depth)}<${keyString}>${newline}`;
-      xml += convertObjectToXml(value, options, depth + 1);
-      xml += `${getIndentation(options, depth)}</${keyString}>${newline}`;
-      continue;
-    }
-
-    // Handle primitive values (string, number, boolean, etc.)
-    xml += `${getIndentation(options, depth)}<${keyString}>${escapeXml(
-      String(value)
-    )}</${keyString}>${newline}`;
-  }
-
-  return depth === 0 ? `${xml}</root>` : xml;
-};
-
-const escapeXml = (str: string): string => {
-  return str
+const escapeXml = (value: string): string => {
+  return value
     .replace(/&/g, '&amp;')
     .replace(/</g, '&lt;')
     .replace(/>/g, '&gt;')
@@ -106,11 +136,8 @@ const escapeXml = (str: string): string => {
 
 const normalizeXmlTagName = (key: string): string => {
   const tagName = key !== '' && !isNaN(Number(key)) ? `row-${key}` : key;
-  const sanitizedTagName = tagName.replace(/[^a-zA-Z0-9_.-]/g, '_');
 
-  if (/^[a-zA-Z_]/.test(sanitizedTagName)) {
-    return sanitizedTagName;
-  }
+  const sanitized = tagName.replace(/[^a-zA-Z0-9_.-]/g, '_');
 
-  return `_${sanitizedTagName}`;
+  return /^[a-zA-Z_]/.test(sanitized) ? sanitized : `_${sanitized}`;
 };

--- a/src/pages/tools/json/json-to-xml/service.ts
+++ b/src/pages/tools/json/json-to-xml/service.ts
@@ -3,6 +3,8 @@ type JsonToXmlOptions = {
   addMetaTag: boolean;
 };
 
+const MAX_XML_DEPTH = 100;
+
 export const convertJsonToXml = (
   json: string,
   options: JsonToXmlOptions
@@ -28,6 +30,10 @@ const convertObjectToXml = (
   options: JsonToXmlOptions,
   depth: number = 0
 ): string => {
+  if (depth > MAX_XML_DEPTH) {
+    throw new Error(`JSON nesting exceeds maximum depth of ${MAX_XML_DEPTH}.`);
+  }
+
   let xml = '';
 
   const newline = options.indentationType === 'none' ? '' : '\n';
@@ -41,7 +47,7 @@ const convertObjectToXml = (
 
   for (const key in obj) {
     const value = obj[key];
-    const keyString = isNaN(Number(key)) ? key : `row-${key}`;
+    const keyString = normalizeXmlTagName(key);
 
     // Handle null values
     if (value === null) {
@@ -96,4 +102,15 @@ const escapeXml = (str: string): string => {
     .replace(/>/g, '&gt;')
     .replace(/"/g, '&quot;')
     .replace(/'/g, '&apos;');
+};
+
+const normalizeXmlTagName = (key: string): string => {
+  const tagName = key !== '' && !isNaN(Number(key)) ? `row-${key}` : key;
+  const sanitizedTagName = tagName.replace(/[^a-zA-Z0-9_.-]/g, '_');
+
+  if (/^[a-zA-Z_]/.test(sanitizedTagName)) {
+    return sanitizedTagName;
+  }
+
+  return `_${sanitizedTagName}`;
 };

--- a/src/pages/tools/json/json-to-xml/types.ts
+++ b/src/pages/tools/json/json-to-xml/types.ts
@@ -1,0 +1,4 @@
+export type InitialValuesType = {
+  indentationType: 'space' | 'tab' | 'none';
+  addMetaTag: boolean;
+};


### PR DESCRIPTION
## Summary
- normalize JSON keys before using them as XML element names
- add a maximum JSON nesting depth guard to avoid recursive stack overflows
- add unit tests for normal conversion, invalid key normalization, and excessive nesting

## Verification
- npx vitest run src/pages/tools/json/json-to-xml/service.test.ts
- npx eslint src/pages/tools/json/json-to-xml/service.ts src/pages/tools/json/json-to-xml/service.test.ts --max-warnings=0
- npm run typecheck

Closes #378