### PR TITLE
fix: replace Math.random() with crypto.getRandomValues() in password generator

### DIFF
--- a/src/lib/secureRandom.test.ts
+++ b/src/lib/secureRandom.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+import { getSecureRandomInt } from './secureRandom';
+
+describe('getSecureRandomInt', () => {
+  it('should return a value within [0, max)', () => {
+    for (let i = 0; i < 1000; i++) {
+      const result = getSecureRandomInt(10);
+      expect(result).toBeGreaterThanOrEqual(0);
+      expect(result).toBeLessThan(10);
+    }
+  });
+
+  it('should return 0 when max is 1', () => {
+    for (let i = 0; i < 100; i++) {
+      const result = getSecureRandomInt(1);
+      expect(result).toBe(0);
+    }
+  });
+
+  it('should throw for max <= 0', () => {
+    expect(() => getSecureRandomInt(0)).toThrow();
+    expect(() => getSecureRandomInt(-1)).toThrow();
+  });
+
+  it('should throw for non-integer max', () => {
+    expect(() => getSecureRandomInt(1.5)).toThrow();
+  });
+
+  it('should produce a roughly uniform distribution', () => {
+    const max = 4;
+    const counts = new Array(max).fill(0);
+    const iterations = 10000;
+
+    for (let i = 0; i < iterations; i++) {
+      counts[getSecureRandomInt(max)]++;
+    }
+
+    // Each value should appear roughly 1/4 of the time.
+    // With 10000 iterations, we expect ~2500 each.
+    // Allow a reasonable margin to avoid flaky tests.
+    for (const count of counts) {
+      expect(count).toBeGreaterThan(2000);
+      expect(count).toBeLessThan(3000);
+    }
+  });
+
+  it('should work with typical charset lengths', () => {
+    // Test with common charset sizes used in password generation
+    for (const max of [26, 52, 62, 90, 85]) {
+      for (let i = 0; i < 100; i++) {
+        const result = getSecureRandomInt(max);
+        expect(result).toBeGreaterThanOrEqual(0);
+        expect(result).toBeLessThan(max);
+      }
+    }
+  });
+});

--- a/src/lib/secureRandom.ts
+++ b/src/lib/secureRandom.ts
@@ -1,0 +1,43 @@
+/**
+ * Cryptographically secure random number generator utilities.
+ *
+ * Uses the Web Crypto API (`crypto.getRandomValues`) instead of `Math.random()`
+ * to prevent predictable outputs in security-sensitive contexts such as
+ * password generation.
+ */
+
+/**
+ * Returns a cryptographically secure random integer in the range [0, max).
+ *
+ * Uses rejection sampling to eliminate the modulo bias that would otherwise
+ * occur when `max` does not evenly divide the output range of the underlying
+ * random source.
+ *
+ * @param max The upper bound (exclusive). Must be a positive integer.
+ * @returns A secure random integer in [0, max).
+ */
+export function getSecureRandomInt(max: number): number {
+  if (max <= 0 || !Number.isInteger(max)) {
+    throw new Error('max must be a positive integer');
+  }
+
+  // Uint32Array produces values in [0, 2^32 - 1], giving 2^32 possible values.
+  const range = 0x100000000; // 2^32
+
+  // Number of values that would introduce bias if we used plain modulo.
+  const rejected = range % max;
+
+  // Values >= this threshold are rejected to ensure a uniform distribution.
+  const limit = range - rejected;
+
+  const array = new Uint32Array(1);
+
+  // Rejection sampling loop.
+  // The rejection zone is extremely small for typical charset sizes (~90),
+  // so this will almost always succeed on the first iteration.
+  do {
+    crypto.getRandomValues(array);
+  } while (array[0] >= limit);
+
+  return array[0] % max;
+}

--- a/src/pages/tools/string/password-generator/service.ts
+++ b/src/pages/tools/string/password-generator/service.ts
@@ -1,4 +1,5 @@
 import type { InitialValuesType } from './initialValues';
+import { getSecureRandomInt } from '../../../../lib/secureRandom';
 
 export function generatePassword(options: InitialValuesType): string {
   const length = parseInt(options.length || '', 10);
@@ -31,7 +32,7 @@ export function generatePassword(options: InitialValuesType): string {
 
   let pwd = '';
   for (let i = 0; i < length; i++) {
-    const idx = Math.floor(Math.random() * charset.length);
+    const idx = getSecureRandomInt(charset.length);
     pwd += charset[idx];
   }
   return pwd;


### PR DESCRIPTION
## Summary

The password generator was using \Math.random()\ which is not cryptographically secure and can produce predictable outputs. This PR replaces it with a new \getSecureRandomInt()\ utility that uses the Web Crypto API (\crypto.getRandomValues\) with rejection sampling to eliminate modulo bias.

## Changes

- **New file**: \src/lib/secureRandom.ts\ — A reusable utility that provides cryptographically secure random integers using the Web Crypto API. Uses rejection sampling to eliminate the modulo bias that would occur when \max\ does not evenly divide the output range of the random source.
- **New file**: \src/lib/secureRandom.test.ts\ — 6 test cases covering range validation, edge cases, error handling, and distribution uniformity.
- **Modified**: \src/pages/tools/string/password-generator/service.ts\ — Replaced \Math.floor(Math.random() * charset.length)\ with \getSecureRandomInt(charset.length)\.

## Testing

- All 19 tests pass (13 existing password generator tests + 6 new secureRandom tests)
- ESLint passes with 0 errors
- Pre-commit hooks (prettier) pass

Fixes #376