### PR TITLE
test: add whitespace-only line case for string reverser

### DIFF
--- a/src/pages/tools/string/reverse/reverse.service.test.ts
+++ b/src/pages/tools/string/reverse/reverse.service.test.ts
@@ -49,4 +49,10 @@ describe('stringReverser', () => {
     const result = stringReverser(input, true, true, false);
     expect(result).toBe('olleh  \n  dlrow');
   });
+
+  it('should preserve whitespace-only lines when emptyItems is true and trim is false', () => {
+    const input = 'hello\n   \nworld';
+    const result = stringReverser(input, true, true, false);
+    expect(result).toBe('olleh\n   \ndlrow');
+  });
 });


### PR DESCRIPTION
Adds a test case for the string reverser service to document the current behavior when processing whitespace-only lines with `emptyItems` enabled and `trim` disabled.

This helps cover an edge case without changing the existing implementation.

Tested with: `npx vitest run src/pages/tools/string/reverse/reverse.service.test.ts`