### PR TITLE
fix(csv-to-xml): escape special characters in CSV cell values

### DIFF
--- a/src/pages/tools/csv/csv-to-xml/csv-to-xml.service.test.ts
+++ b/src/pages/tools/csv/csv-to-xml/csv-to-xml.service.test.ts
@@ -1,8 +1,9 @@
 import { describe, it, expect } from 'vitest';
 import { convertCsvToXml } from './service';
+import { InitialValuesType } from './index';
 
 describe('CsvToXml Service', () => {
-  const defaultOptions = {
+  const defaultOptions: InitialValuesType = {
     delimiter: ',',
     quote: '"',
     comment: '#',

--- a/src/pages/tools/csv/csv-to-xml/csv-to-xml.service.test.ts
+++ b/src/pages/tools/csv/csv-to-xml/csv-to-xml.service.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest';
+import { convertCsvToXml } from './service';
+
+describe('CsvToXml Service', () => {
+  const defaultOptions = {
+    delimiter: ',',
+    quote: '"',
+    comment: '#',
+    useHeaders: true,
+    skipEmptyLines: true
+  };
+
+  it('should escape ampersands in cell values to produce valid XML', () => {
+    const csvInput = 'name\nA&B';
+    const result = convertCsvToXml(csvInput, defaultOptions);
+
+    expect(result).toContain('<name>A&amp;B</name>');
+    expect(result).toContain('<?xml version="1.0" encoding="UTF-8" ?>');
+  });
+
+  it('should leave normal text without metacharacters untouched', () => {
+    const csvInput = 'name\nA and B';
+    const result = convertCsvToXml(csvInput, defaultOptions);
+
+    expect(result).toContain('<name>A and B</name>');
+  });
+
+  it('shold escape all dangerous XML characters in CSV values', () => {
+    const csvInput = 'value\n<tag> text & text';
+    const result = convertCsvToXml(csvInput, defaultOptions);
+
+    expect(result).toContain('<value>&lt;tag&gt; text &amp; text</value>');
+  });
+});

--- a/src/pages/tools/csv/csv-to-xml/service.ts
+++ b/src/pages/tools/csv/csv-to-xml/service.ts
@@ -1,3 +1,5 @@
+import { escapeHtml } from '@utils/string';
+
 type CsvToXmlOptions = {
   delimiter: string;
   quote: string;
@@ -35,7 +37,8 @@ export const convertCsvToXml = (
     const values = parseCsvLine(line, options);
     xmlResult += `  <row id="${index}">\n`;
     headers.forEach((header, i) => {
-      xmlResult += `    <${header}>${values[i] || ''}</${header}>\n`;
+      const safeValue = escapeHtml(values[i] || '');
+      xmlResult += `    <${header}>${safeValue}</${header}>\n`;
     });
     xmlResult += `  </row>\n`;
   });


### PR DESCRIPTION
Closes 405

### Fix Summary
- Resolved the XML malformation issue by safely escaping CSV cell text before interpolation into the element contents.
- Reused the project's existing shared utility function `escapeHtml` from `@utils/string` to prevent redundant code.
- Created `csv-to-xml.service.test.ts` and successfully implemented both requested test cases:
  1. A regression test verifying that `name\nA&B` correctly outputs `<name>A&amp;B</name>`.
  2. A neighboring control test asserting that standard strings like `name\nA and B` remain unimpacted.

All Vitest assertions are passing successfully. Ready for review!
