### PR TITLE
fix: escape cell text and sanitize header tag names in CSV-to-XML

### DIFF
--- a/src/pages/tools/csv/csv-to-xml/csv-to-xml.service.test.ts
+++ b/src/pages/tools/csv/csv-to-xml/csv-to-xml.service.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+import { convertCsvToXml } from './service';
+
+describe('convertCsvToXml', () => {
+  const defaultOptions = {
+    delimiter: ',',
+    quote: '"',
+    comment: '#',
+    useHeaders: true,
+    skipEmptyLines: true
+  };
+
+  it('should convert simple CSV with headers', () => {
+    const result = convertCsvToXml('name,age\nJohn,30', defaultOptions);
+    expect(result).toEqual(
+      `<?xml version="1.0" encoding="UTF-8" ?>\n<root>\n  <row id="0">\n    <name>John</name>\n    <age>30</age>\n  </row>\n</root>`
+    );
+  });
+
+  it('should return empty root for empty input', () => {
+    const result = convertCsvToXml('', defaultOptions);
+    expect(result).toEqual(
+      `<?xml version="1.0" encoding="UTF-8" ?>\n<root></root>`
+    );
+  });
+
+  it('should escape ampersands in cell values (#405)', () => {
+    const result = convertCsvToXml('name\nA&B', defaultOptions);
+    expect(result).toContain('<name>A&amp;B</name>');
+  });
+
+  it('should escape angle brackets and quotes in cell values', () => {
+    const result = convertCsvToXml(
+      `name,note\n<script>,"say ""hi"" & 'bye'"`,
+      defaultOptions
+    );
+    expect(result).toContain('<name>&lt;script&gt;</name>');
+    expect(result).toContain('<note>say hi &amp; &apos;bye&apos;</note>');
+  });
+
+  it('should sanitize header names into valid XML tag names', () => {
+    const result = convertCsvToXml('first name,a&b\nJohn,yes', defaultOptions);
+    expect(result).toContain('<first_name>John</first_name>');
+    expect(result).toContain('<a_b>yes</a_b>');
+  });
+
+  it('should prefix numeric header names', () => {
+    const result = convertCsvToXml('2024\nvalue', defaultOptions);
+    expect(result).toContain('<column-2024>value</column-2024>');
+  });
+
+  it('should skip comment lines', () => {
+    const result = convertCsvToXml('name\n#comment\nJohn', defaultOptions);
+    expect(result).not.toContain('comment');
+    expect(result).toContain('<name>John</name>');
+  });
+});

--- a/src/pages/tools/csv/csv-to-xml/service.ts
+++ b/src/pages/tools/csv/csv-to-xml/service.ts
@@ -35,13 +35,34 @@ export const convertCsvToXml = (
     const values = parseCsvLine(line, options);
     xmlResult += `  <row id="${index}">\n`;
     headers.forEach((header, i) => {
-      xmlResult += `    <${header}>${values[i] || ''}</${header}>\n`;
+      const tagName = normalizeXmlTagName(header);
+      xmlResult += `    <${tagName}>${escapeXml(
+        values[i] || ''
+      )}</${tagName}>\n`;
     });
     xmlResult += `  </row>\n`;
   });
 
   xmlResult += `</root>`;
   return xmlResult;
+};
+
+const escapeXml = (value: string): string => {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;');
+};
+
+const normalizeXmlTagName = (header: string): string => {
+  const tagName =
+    header !== '' && !isNaN(Number(header)) ? `column-${header}` : header;
+
+  const sanitized = tagName.replace(/[^a-zA-Z0-9_.-]/g, '_');
+
+  return /^[a-zA-Z_]/.test(sanitized) ? sanitized : `_${sanitized}`;
 };
 
 const parseCsvLine = (line: string, options: CsvToXmlOptions): string[] => {


### PR DESCRIPTION
## What

Fixes #405 — the CSV-to-XML converter interpolated cell text and header names directly into the XML output, so ordinary CSV values containing `&` or `<` produced malformed XML (e.g. `name` / `A&B` emitted `<name>A&B</name>`, which fails XML parsing at the ampersand).

## How

Applies the same approach as the JSON-to-XML fix in #396:

- **Cell values** are escaped with the same `escapeXml` rules (`&`, `<`, `>`, `\"`, `'`).
- **Header names** (used as element names) are sanitized with the same `normalizeXmlTagName` rules — invalid characters become `_`, names that don't start with a letter/underscore are prefixed, and purely numeric headers become `column-<n>` (mirroring `row-<n>` in #396).

## Testing

- New `csv-to-xml.service.test.ts` with 7 tests covering the reported `A&B` repro, angle brackets/quotes in cells, header sanitization, numeric headers, comments, and empty input — all passing.
- `npx tsc --noEmit` clean.
- Output for the issue's repro now validates: `<name>A&amp;B</name>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)