### PR TITLE
feat: add date weekday calculator tool

### DIFF
--- a/public/locales/en/time.json
+++ b/public/locales/en/time.json
@@ -151,6 +151,60 @@
       "description": "Discord timestamps are a special syntax that displays dates and times dynamically. Instead of showing a fixed time, they automatically convert to each viewer's local timezone and language — so everyone sees the correct time for their location. Simply enter one datetime per line, choose a format, and paste the results directly into Discord. The tool processes each line independently — blank lines are preserved in the output, invalid lines are flagged with ❌, and valid datetimes are converted instantly. Enable UTC mode to ensure consistent results regardless of your local timezone."
     }
   },
+  "dateWeekdayCalculator": {
+    "title": "Date Weekday Calculator",
+    "description": "Find every year in a range where a month and day fall on a chosen weekday.",
+    "shortDescription": "Find years when a date falls on a weekday",
+    "longDescription": "Select a month, day, and target weekday, then choose a start and end year. The calculator scans each year in the range and lists every match as a full formatted date. February 29 is supported: non-leap years are skipped automatically. Invalid dates (such as April 31) and invalid year ranges show clear error messages.",
+    "resultTitle": "Matching years",
+    "dateSelection": "Date",
+    "monthDescription": "Month",
+    "dayDescription": "Day",
+    "weekdaySelection": "Weekday",
+    "weekdayDescription": "Target weekday",
+    "yearRange": "Year range",
+    "startYearDescription": "Start year",
+    "endYearDescription": "End year",
+    "noMatches": "No matching years found in the selected range.",
+    "foundMatches_one": "Found {{count}} matching year",
+    "foundMatches_other": "Found {{count}} matching years",
+    "months": {
+      "1": "January",
+      "2": "February",
+      "3": "March",
+      "4": "April",
+      "5": "May",
+      "6": "June",
+      "7": "July",
+      "8": "August",
+      "9": "September",
+      "10": "October",
+      "11": "November",
+      "12": "December"
+    },
+    "weekdays": {
+      "monday": "Monday",
+      "tuesday": "Tuesday",
+      "wednesday": "Wednesday",
+      "thursday": "Thursday",
+      "friday": "Friday",
+      "saturday": "Saturday",
+      "sunday": "Sunday"
+    },
+    "errors": {
+      "invalidMonth": "Month must be between 1 and 12",
+      "invalidDay": "Day must be between 1 and 31",
+      "invalidDate": "Invalid day for the selected month",
+      "invalidWeekday": "Invalid weekday",
+      "invalidYear": "Years must be integers between 1 and 9999",
+      "invalidYearRange": "Start year must be less than or equal to end year",
+      "emptyInput": "All fields are required",
+      "fallback": "Invalid input"
+    },
+    "toolInfo": {
+      "title": "What is a {{title}}?"
+    }
+  },
   "convertDateToUnix": {
     "description": "Convert a human-readable date to a Unix Timestamp.",
     "outputOptions": "Output Options",

--- a/src/pages/tools/time/date-weekday-calculator/date-weekday-calculator.service.test.ts
+++ b/src/pages/tools/time/date-weekday-calculator/date-weekday-calculator.service.test.ts
@@ -1,0 +1,202 @@
+import { describe, expect, it } from 'vitest';
+import {
+  DATE_WEEKDAY_ERRORS,
+  findMatchingYears,
+  formatMatchingYearsResult,
+  parseAndFindMatchingYears
+} from './service';
+
+describe('date-weekday-calculator', () => {
+  it('finds multiple matching years for a normal date', () => {
+    const result = findMatchingYears({
+      month: 7,
+      day: 23,
+      weekday: 'friday',
+      startYear: 2000,
+      endYear: 2050
+    });
+
+    expect(result.count).toBe(7);
+    expect(result.matches.map((match) => match.year)).toEqual([
+      2004, 2010, 2021, 2027, 2032, 2038, 2049
+    ]);
+    expect(result.matches[2]?.formatted).toBe('Friday, July 23, 2021');
+    expect(result.matches[2]?.date).toBeInstanceOf(Date);
+  });
+
+  it('includes February 29 only in leap years that match the weekday', () => {
+    const result = findMatchingYears({
+      month: 2,
+      day: 29,
+      weekday: 'monday',
+      startYear: 2000,
+      endYear: 2100
+    });
+
+    expect(result.matches.map((match) => match.year)).toEqual([
+      2016, 2044, 2072
+    ]);
+    expect(result.matches[0]?.formatted).toBe('Monday, February 29, 2016');
+  });
+
+  it('rejects invalid dates like April 31', () => {
+    expect(() =>
+      findMatchingYears({
+        month: 4,
+        day: 31,
+        weekday: 'monday',
+        startYear: 2000,
+        endYear: 2050
+      })
+    ).toThrow(DATE_WEEKDAY_ERRORS.INVALID_DATE);
+  });
+
+  it('returns empty results when nothing matches', () => {
+    const result = findMatchingYears({
+      month: 7,
+      day: 23,
+      weekday: 'friday',
+      startYear: 2022,
+      endYear: 2022
+    });
+
+    expect(result.count).toBe(0);
+    expect(result.matches).toEqual([]);
+    expect(formatMatchingYearsResult(result)).toBe(
+      'No matching years found in the selected range.'
+    );
+  });
+
+  it('rejects invalid year ranges', () => {
+    expect(() =>
+      findMatchingYears({
+        month: 7,
+        day: 23,
+        weekday: 'friday',
+        startYear: 2050,
+        endYear: 2000
+      })
+    ).toThrow(DATE_WEEKDAY_ERRORS.INVALID_YEAR_RANGE);
+  });
+
+  it('rejects years outside 1–9999', () => {
+    expect(() =>
+      findMatchingYears({
+        month: 7,
+        day: 23,
+        weekday: 'friday',
+        startYear: 0,
+        endYear: 2000
+      })
+    ).toThrow(DATE_WEEKDAY_ERRORS.INVALID_YEAR);
+
+    expect(() =>
+      findMatchingYears({
+        month: 7,
+        day: 23,
+        weekday: 'friday',
+        startYear: 2000,
+        endYear: 10000
+      })
+    ).toThrow(DATE_WEEKDAY_ERRORS.INVALID_YEAR);
+  });
+
+  it('handles boundary years when start equals end', () => {
+    const match = findMatchingYears({
+      month: 7,
+      day: 23,
+      weekday: 'friday',
+      startYear: 2021,
+      endYear: 2021
+    });
+    expect(match.count).toBe(1);
+    expect(match.matches[0]?.year).toBe(2021);
+
+    const miss = findMatchingYears({
+      month: 7,
+      day: 23,
+      weekday: 'friday',
+      startYear: 2022,
+      endYear: 2022
+    });
+    expect(miss.count).toBe(0);
+  });
+
+  it('handles years below 100 without the Date 1900-offset', () => {
+    const result = findMatchingYears({
+      month: 1,
+      day: 1,
+      weekday: 'saturday',
+      startYear: 50,
+      endYear: 50
+    });
+
+    expect(result.matches.map((match) => match.year)).toEqual([50]);
+    expect(result.matches[0]?.date.getFullYear()).toBe(50);
+  });
+
+  it('handles the far end of the supported range', () => {
+    const result = findMatchingYears({
+      month: 12,
+      day: 31,
+      weekday: 'friday',
+      startYear: 9999,
+      endYear: 9999
+    });
+
+    expect(result.count).toBe(1);
+    expect(result.matches[0]?.year).toBe(9999);
+  });
+
+  it('rejects empty string inputs when parsing', () => {
+    expect(() =>
+      parseAndFindMatchingYears({
+        month: '7',
+        day: '23',
+        weekday: 'friday',
+        startYear: '',
+        endYear: '2050'
+      })
+    ).toThrow(DATE_WEEKDAY_ERRORS.EMPTY_INPUT);
+  });
+
+  it('rejects non-integer numeric strings when parsing', () => {
+    expect(() =>
+      parseAndFindMatchingYears({
+        month: '7.5',
+        day: '23',
+        weekday: 'friday',
+        startYear: '2000',
+        endYear: '2050'
+      })
+    ).toThrow(DATE_WEEKDAY_ERRORS.EMPTY_INPUT);
+  });
+
+  it('formats a summary with matching years', () => {
+    const result = findMatchingYears({
+      month: 7,
+      day: 23,
+      weekday: 'friday',
+      startYear: 2021,
+      endYear: 2027
+    });
+
+    expect(formatMatchingYearsResult(result)).toBe(
+      'Found 2 matching years\n\nFriday, July 23, 2021\nFriday, July 23, 2027'
+    );
+  });
+
+  it('formats a singular summary for one match', () => {
+    const result = findMatchingYears({
+      month: 7,
+      day: 23,
+      weekday: 'friday',
+      startYear: 2021,
+      endYear: 2021
+    });
+
+    expect(formatMatchingYearsResult(result)).toBe(
+      'Found 1 matching year\n\nFriday, July 23, 2021'
+    );
+  });
+});

--- a/src/pages/tools/time/date-weekday-calculator/index.tsx
+++ b/src/pages/tools/time/date-weekday-calculator/index.tsx
@@ -10,7 +10,8 @@ import { useTranslation } from 'react-i18next';
 import {
   DATE_WEEKDAY_ERRORS,
   formatMatchingYearsResult,
-  parseAndFindMatchingYears
+  parseAndFindMatchingYears,
+  MAX_DAY_BY_MONTH
 } from './service';
 import { InitialValuesType, Weekday } from './types';
 
@@ -37,10 +38,14 @@ const MONTH_VALUES = [
   '12'
 ] as const;
 
-const DAY_OPTIONS = Array.from({ length: 31 }, (_, index) => {
-  const day = String(index + 1);
-  return { value: day, label: day };
-});
+const getDayOptions = (month: string) => {
+  const maxDay = MAX_DAY_BY_MONTH[Number(month) - 1] ?? 31;
+
+  return Array.from({ length: maxDay }, (_, index) => {
+    const day = String(index + 1);
+    return { value: day, label: day };
+  });
+};
 
 const WEEKDAY_VALUES: Weekday[] = [
   'monday',
@@ -155,57 +160,72 @@ export default function DateWeekdayCalculator({
         title: t('dateWeekdayCalculator.toolInfo.title', { title }),
         description: longDescription
       }}
-      getGroups={({ values, updateField }) => [
-        {
-          title: t('dateWeekdayCalculator.dateSelection'),
-          component: (
-            <Box>
+      getGroups={({ values, updateField }) => {
+        const dayOptions = getDayOptions(values.month);
+
+        return [
+          {
+            title: t('dateWeekdayCalculator.dateSelection'),
+            component: (
+              <Box>
+                <SelectWithDesc
+                  description={t('dateWeekdayCalculator.monthDescription')}
+                  selected={values.month}
+                  onChange={(value) => {
+                    updateField('month', value);
+
+                    // Clamp the selected day down if it no longer fits
+                    // the newly selected month (e.g. switching from
+                    // January 31 to February should land on 29, not
+                    // leave an out-of-range day selected).
+                    const newMaxDay = MAX_DAY_BY_MONTH[Number(value) - 1];
+                    if (newMaxDay && Number(values.day) > newMaxDay) {
+                      updateField('day', String(newMaxDay));
+                    }
+                  }}
+                  options={monthOptions}
+                />
+                <SelectWithDesc
+                  description={t('dateWeekdayCalculator.dayDescription')}
+                  selected={values.day}
+                  onChange={(value) => updateField('day', value)}
+                  options={dayOptions}
+                />
+              </Box>
+            )
+          },
+          {
+            title: t('dateWeekdayCalculator.weekdaySelection'),
+            component: (
               <SelectWithDesc
-                description={t('dateWeekdayCalculator.monthDescription')}
-                selected={values.month}
-                onChange={(value) => updateField('month', value)}
-                options={monthOptions}
+                description={t('dateWeekdayCalculator.weekdayDescription')}
+                selected={values.weekday}
+                onChange={(value) => updateField('weekday', value)}
+                options={weekdayOptions}
               />
-              <SelectWithDesc
-                description={t('dateWeekdayCalculator.dayDescription')}
-                selected={values.day}
-                onChange={(value) => updateField('day', value)}
-                options={DAY_OPTIONS}
-              />
-            </Box>
-          )
-        },
-        {
-          title: t('dateWeekdayCalculator.weekdaySelection'),
-          component: (
-            <SelectWithDesc
-              description={t('dateWeekdayCalculator.weekdayDescription')}
-              selected={values.weekday}
-              onChange={(value) => updateField('weekday', value)}
-              options={weekdayOptions}
-            />
-          )
-        },
-        {
-          title: t('dateWeekdayCalculator.yearRange'),
-          component: (
-            <Box>
-              <TextFieldWithDesc
-                description={t('dateWeekdayCalculator.startYearDescription')}
-                value={values.startYear}
-                onOwnChange={(value) => updateField('startYear', value)}
-                type="number"
-              />
-              <TextFieldWithDesc
-                description={t('dateWeekdayCalculator.endYearDescription')}
-                value={values.endYear}
-                onOwnChange={(value) => updateField('endYear', value)}
-                type="number"
-              />
-            </Box>
-          )
-        }
-      ]}
+            )
+          },
+          {
+            title: t('dateWeekdayCalculator.yearRange'),
+            component: (
+              <Box>
+                <TextFieldWithDesc
+                  description={t('dateWeekdayCalculator.startYearDescription')}
+                  value={values.startYear}
+                  onOwnChange={(value) => updateField('startYear', value)}
+                  type="number"
+                />
+                <TextFieldWithDesc
+                  description={t('dateWeekdayCalculator.endYearDescription')}
+                  value={values.endYear}
+                  onOwnChange={(value) => updateField('endYear', value)}
+                  type="number"
+                />
+              </Box>
+            )
+          }
+        ];
+      }}
       compute={(values) => {
         try {
           const matches = parseAndFindMatchingYears(values);

--- a/src/pages/tools/time/date-weekday-calculator/index.tsx
+++ b/src/pages/tools/time/date-weekday-calculator/index.tsx
@@ -1,0 +1,232 @@
+import { Box } from '@mui/material';
+import { useState } from 'react';
+import ToolContent from '@components/ToolContent';
+import ToolTextResult from '@components/result/ToolTextResult';
+import SelectWithDesc from '@components/options/SelectWithDesc';
+import TextFieldWithDesc from '@components/options/TextFieldWithDesc';
+import { CardExampleType } from '@components/examples/ToolExamples';
+import { ToolComponentProps } from '@tools/defineTool';
+import { useTranslation } from 'react-i18next';
+import {
+  DATE_WEEKDAY_ERRORS,
+  formatMatchingYearsResult,
+  parseAndFindMatchingYears
+} from './service';
+import { InitialValuesType, Weekday } from './types';
+
+const initialValues: InitialValuesType = {
+  month: '7',
+  day: '23',
+  weekday: 'friday',
+  startYear: '2000',
+  endYear: '2050'
+};
+
+const MONTH_VALUES = [
+  '1',
+  '2',
+  '3',
+  '4',
+  '5',
+  '6',
+  '7',
+  '8',
+  '9',
+  '10',
+  '11',
+  '12'
+] as const;
+
+const DAY_OPTIONS = Array.from({ length: 31 }, (_, index) => {
+  const day = String(index + 1);
+  return { value: day, label: day };
+});
+
+const WEEKDAY_VALUES: Weekday[] = [
+  'monday',
+  'tuesday',
+  'wednesday',
+  'thursday',
+  'friday',
+  'saturday',
+  'sunday'
+];
+
+const ERROR_I18N_KEYS = {
+  [DATE_WEEKDAY_ERRORS.INVALID_MONTH]:
+    'dateWeekdayCalculator.errors.invalidMonth',
+  [DATE_WEEKDAY_ERRORS.INVALID_DAY]: 'dateWeekdayCalculator.errors.invalidDay',
+  [DATE_WEEKDAY_ERRORS.INVALID_DATE]:
+    'dateWeekdayCalculator.errors.invalidDate',
+  [DATE_WEEKDAY_ERRORS.INVALID_WEEKDAY]:
+    'dateWeekdayCalculator.errors.invalidWeekday',
+  [DATE_WEEKDAY_ERRORS.INVALID_YEAR]:
+    'dateWeekdayCalculator.errors.invalidYear',
+  [DATE_WEEKDAY_ERRORS.INVALID_YEAR_RANGE]:
+    'dateWeekdayCalculator.errors.invalidYearRange',
+  [DATE_WEEKDAY_ERRORS.EMPTY_INPUT]: 'dateWeekdayCalculator.errors.emptyInput'
+} as const;
+
+const exampleCards: CardExampleType<InitialValuesType>[] = [
+  {
+    title: 'July 23 on Friday',
+    description:
+      'Find every year between 2000 and 2050 where July 23 falls on a Friday.',
+    sampleOptions: {
+      month: '7',
+      day: '23',
+      weekday: 'friday',
+      startYear: '2000',
+      endYear: '2050'
+    },
+    sampleResult: `Found 7 matching years
+
+Friday, July 23, 2004
+Friday, July 23, 2010
+Friday, July 23, 2021
+Friday, July 23, 2027
+Friday, July 23, 2032
+Friday, July 23, 2038
+Friday, July 23, 2049`
+  },
+  {
+    title: 'Leap day on Monday',
+    description:
+      'Find leap days (February 29) that fall on a Monday between 2000 and 2100. Non-leap years are skipped automatically.',
+    sampleOptions: {
+      month: '2',
+      day: '29',
+      weekday: 'monday',
+      startYear: '2000',
+      endYear: '2100'
+    },
+    sampleResult: `Found 3 matching years
+
+Monday, February 29, 2016
+Monday, February 29, 2044
+Monday, February 29, 2072`
+  },
+  {
+    title: 'Single-year range',
+    description: 'Check whether a specific year matches the selected weekday.',
+    sampleOptions: {
+      month: '7',
+      day: '23',
+      weekday: 'friday',
+      startYear: '2021',
+      endYear: '2021'
+    },
+    sampleResult: `Found 1 matching year
+
+Friday, July 23, 2021`
+  }
+];
+
+export default function DateWeekdayCalculator({
+  title,
+  longDescription
+}: ToolComponentProps) {
+  const { t } = useTranslation('time');
+  const [result, setResult] = useState('');
+
+  const monthOptions = MONTH_VALUES.map((value) => ({
+    value,
+    label: t(`dateWeekdayCalculator.months.${value}`)
+  }));
+
+  const weekdayOptions = WEEKDAY_VALUES.map((value) => ({
+    value,
+    label: t(`dateWeekdayCalculator.weekdays.${value}`)
+  }));
+
+  return (
+    <ToolContent
+      title={title}
+      inputComponent={null}
+      resultComponent={
+        <ToolTextResult
+          title={t('dateWeekdayCalculator.resultTitle')}
+          value={result}
+        />
+      }
+      initialValues={initialValues}
+      exampleCards={exampleCards}
+      toolInfo={{
+        title: t('dateWeekdayCalculator.toolInfo.title', { title }),
+        description: longDescription
+      }}
+      getGroups={({ values, updateField }) => [
+        {
+          title: t('dateWeekdayCalculator.dateSelection'),
+          component: (
+            <Box>
+              <SelectWithDesc
+                description={t('dateWeekdayCalculator.monthDescription')}
+                selected={values.month}
+                onChange={(value) => updateField('month', value)}
+                options={monthOptions}
+              />
+              <SelectWithDesc
+                description={t('dateWeekdayCalculator.dayDescription')}
+                selected={values.day}
+                onChange={(value) => updateField('day', value)}
+                options={DAY_OPTIONS}
+              />
+            </Box>
+          )
+        },
+        {
+          title: t('dateWeekdayCalculator.weekdaySelection'),
+          component: (
+            <SelectWithDesc
+              description={t('dateWeekdayCalculator.weekdayDescription')}
+              selected={values.weekday}
+              onChange={(value) => updateField('weekday', value)}
+              options={weekdayOptions}
+            />
+          )
+        },
+        {
+          title: t('dateWeekdayCalculator.yearRange'),
+          component: (
+            <Box>
+              <TextFieldWithDesc
+                description={t('dateWeekdayCalculator.startYearDescription')}
+                value={values.startYear}
+                onOwnChange={(value) => updateField('startYear', value)}
+                type="number"
+              />
+              <TextFieldWithDesc
+                description={t('dateWeekdayCalculator.endYearDescription')}
+                value={values.endYear}
+                onOwnChange={(value) => updateField('endYear', value)}
+                type="number"
+              />
+            </Box>
+          )
+        }
+      ]}
+      compute={(values) => {
+        try {
+          const matches = parseAndFindMatchingYears(values);
+          setResult(
+            formatMatchingYearsResult(matches, {
+              noMatches: t('dateWeekdayCalculator.noMatches'),
+              foundMatches: (count) =>
+                t('dateWeekdayCalculator.foundMatches', { count })
+            })
+          );
+        } catch (error) {
+          if (!(error instanceof Error)) {
+            setResult(t('dateWeekdayCalculator.errors.fallback'));
+            return;
+          }
+
+          const key =
+            ERROR_I18N_KEYS[error.message as keyof typeof ERROR_I18N_KEYS];
+          setResult(key ? t(key) : t('dateWeekdayCalculator.errors.fallback'));
+        }
+      }}
+    />
+  );
+}

--- a/src/pages/tools/time/date-weekday-calculator/meta.ts
+++ b/src/pages/tools/time/date-weekday-calculator/meta.ts
@@ -1,0 +1,26 @@
+import { defineTool } from '@tools/defineTool';
+import { lazy } from 'react';
+
+export const tool = defineTool('time', {
+  path: 'date-weekday-calculator',
+  icon: 'material-symbols:calendar-month',
+
+  keywords: [
+    'date',
+    'weekday',
+    'day of week',
+    'calendar',
+    'year',
+    'matching years',
+    'what day',
+    'leap day'
+  ],
+  component: lazy(() => import('./index')),
+  i18n: {
+    name: 'time:dateWeekdayCalculator.title',
+    description: 'time:dateWeekdayCalculator.description',
+    shortDescription: 'time:dateWeekdayCalculator.shortDescription',
+    longDescription: 'time:dateWeekdayCalculator.longDescription',
+    userTypes: ['generalUsers']
+  }
+});

--- a/src/pages/tools/time/date-weekday-calculator/service.ts
+++ b/src/pages/tools/time/date-weekday-calculator/service.ts
@@ -1,0 +1,179 @@
+import dayjs from 'dayjs';
+import {
+  FindMatchingYearsInput,
+  FindMatchingYearsResult,
+  MatchingYear,
+  Weekday
+} from './types';
+
+export const DATE_WEEKDAY_ERRORS = {
+  INVALID_MONTH: 'Month must be between 1 and 12',
+  INVALID_DAY: 'Day must be between 1 and 31',
+  INVALID_DATE: 'Invalid day for the selected month',
+  INVALID_WEEKDAY: 'Invalid weekday',
+  INVALID_YEAR: 'Years must be integers between 1 and 9999',
+  INVALID_YEAR_RANGE: 'Start year must be less than or equal to end year',
+  EMPTY_INPUT: 'All fields are required'
+} as const;
+
+const WEEKDAY_TO_DAYJS: Record<Weekday, number> = {
+  sunday: 0,
+  monday: 1,
+  tuesday: 2,
+  wednesday: 3,
+  thursday: 4,
+  friday: 5,
+  saturday: 6
+};
+
+/** Max valid day per month; February allows 29 (skipped in non-leap years). */
+const MAX_DAY_BY_MONTH = [31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
+
+const MIN_YEAR = 1;
+const MAX_YEAR = 9999;
+
+function isWeekday(value: string): value is Weekday {
+  return value in WEEKDAY_TO_DAYJS;
+}
+
+function createDate(year: number, month: number, day: number): Date {
+  const date = new Date(year, month - 1, day);
+  // The Date constructor maps years 0-99 to 1900-1999, so set the year explicitly.
+  date.setFullYear(year);
+  return date;
+}
+
+/** False when the day overflowed into the next month, e.g. Feb 29 in a non-leap year. */
+function dateExists(
+  date: Date,
+  year: number,
+  month: number,
+  day: number
+): boolean {
+  return (
+    date.getFullYear() === year &&
+    date.getMonth() === month - 1 &&
+    date.getDate() === day
+  );
+}
+
+export function findMatchingYears(
+  input: FindMatchingYearsInput
+): FindMatchingYearsResult {
+  const { month, day, weekday, startYear, endYear } = input;
+
+  if (
+    !Number.isFinite(month) ||
+    !Number.isFinite(day) ||
+    !Number.isFinite(startYear) ||
+    !Number.isFinite(endYear)
+  ) {
+    throw new Error(DATE_WEEKDAY_ERRORS.EMPTY_INPUT);
+  }
+
+  if (!Number.isInteger(month) || month < 1 || month > 12) {
+    throw new Error(DATE_WEEKDAY_ERRORS.INVALID_MONTH);
+  }
+
+  if (!Number.isInteger(day) || day < 1 || day > 31) {
+    throw new Error(DATE_WEEKDAY_ERRORS.INVALID_DAY);
+  }
+
+  if (day > MAX_DAY_BY_MONTH[month - 1]) {
+    throw new Error(DATE_WEEKDAY_ERRORS.INVALID_DATE);
+  }
+
+  if (!isWeekday(weekday)) {
+    throw new Error(DATE_WEEKDAY_ERRORS.INVALID_WEEKDAY);
+  }
+
+  if (
+    !Number.isInteger(startYear) ||
+    !Number.isInteger(endYear) ||
+    startYear < MIN_YEAR ||
+    endYear > MAX_YEAR ||
+    startYear > MAX_YEAR ||
+    endYear < MIN_YEAR
+  ) {
+    throw new Error(DATE_WEEKDAY_ERRORS.INVALID_YEAR);
+  }
+
+  if (startYear > endYear) {
+    throw new Error(DATE_WEEKDAY_ERRORS.INVALID_YEAR_RANGE);
+  }
+
+  const targetWeekday = WEEKDAY_TO_DAYJS[weekday];
+  const matches: MatchingYear[] = [];
+
+  for (let year = startYear; year <= endYear; year += 1) {
+    const date = createDate(year, month, day);
+
+    if (
+      !dateExists(date, year, month, day) ||
+      date.getDay() !== targetWeekday
+    ) {
+      continue;
+    }
+
+    matches.push({
+      year,
+      date,
+      formatted: dayjs(date).format('dddd, MMMM D, YYYY')
+    });
+  }
+
+  return { matches, count: matches.length };
+}
+
+export type FormatMatchingYearsMessages = {
+  noMatches: string;
+  foundMatches: (count: number) => string;
+};
+
+export function formatMatchingYearsResult(
+  result: FindMatchingYearsResult,
+  messages: FormatMatchingYearsMessages = {
+    noMatches: 'No matching years found in the selected range.',
+    foundMatches: (count) =>
+      count === 1 ? 'Found 1 matching year' : `Found ${count} matching years`
+  }
+): string {
+  if (result.count === 0) {
+    return messages.noMatches;
+  }
+
+  return `${messages.foundMatches(result.count)}\n\n${result.matches
+    .map((match) => match.formatted)
+    .join('\n')}`;
+}
+
+function parseRequiredInt(value: string): number {
+  const trimmed = value.trim();
+  if (trimmed === '') {
+    throw new Error(DATE_WEEKDAY_ERRORS.EMPTY_INPUT);
+  }
+  if (!/^\d+$/.test(trimmed)) {
+    throw new Error(DATE_WEEKDAY_ERRORS.EMPTY_INPUT);
+  }
+  return Number.parseInt(trimmed, 10);
+}
+
+export function parseAndFindMatchingYears(values: {
+  month: string;
+  day: string;
+  weekday: string;
+  startYear: string;
+  endYear: string;
+}): FindMatchingYearsResult {
+  if (values.weekday.trim() === '') {
+    throw new Error(DATE_WEEKDAY_ERRORS.EMPTY_INPUT);
+  }
+
+  return findMatchingYears({
+    month: parseRequiredInt(values.month),
+    day: parseRequiredInt(values.day),
+    weekday: values.weekday as Weekday,
+    startYear: parseRequiredInt(values.startYear),
+    endYear: parseRequiredInt(values.endYear)
+  });
+}

--- a/src/pages/tools/time/date-weekday-calculator/service.ts
+++ b/src/pages/tools/time/date-weekday-calculator/service.ts
@@ -27,7 +27,9 @@ const WEEKDAY_TO_DAYJS: Record<Weekday, number> = {
 };
 
 /** Max valid day per month; February allows 29 (skipped in non-leap years). */
-const MAX_DAY_BY_MONTH = [31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
+export const MAX_DAY_BY_MONTH = [
+  31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31
+];
 
 const MIN_YEAR = 1;
 const MAX_YEAR = 9999;
@@ -165,14 +167,16 @@ export function parseAndFindMatchingYears(values: {
   startYear: string;
   endYear: string;
 }): FindMatchingYearsResult {
-  if (values.weekday.trim() === '') {
+  const weekday = values.weekday.trim();
+
+  if (weekday === '') {
     throw new Error(DATE_WEEKDAY_ERRORS.EMPTY_INPUT);
   }
 
   return findMatchingYears({
     month: parseRequiredInt(values.month),
     day: parseRequiredInt(values.day),
-    weekday: values.weekday as Weekday,
+    weekday: weekday as Weekday,
     startYear: parseRequiredInt(values.startYear),
     endYear: parseRequiredInt(values.endYear)
   });

--- a/src/pages/tools/time/date-weekday-calculator/types.ts
+++ b/src/pages/tools/time/date-weekday-calculator/types.ts
@@ -1,0 +1,35 @@
+export type Weekday =
+  | 'sunday'
+  | 'monday'
+  | 'tuesday'
+  | 'wednesday'
+  | 'thursday'
+  | 'friday'
+  | 'saturday';
+
+export interface FindMatchingYearsInput {
+  month: number;
+  day: number;
+  weekday: Weekday;
+  startYear: number;
+  endYear: number;
+}
+
+export interface MatchingYear {
+  year: number;
+  date: Date;
+  formatted: string;
+}
+
+export interface FindMatchingYearsResult {
+  matches: MatchingYear[];
+  count: number;
+}
+
+export type InitialValuesType = {
+  month: string;
+  day: string;
+  weekday: Weekday;
+  startYear: string;
+  endYear: string;
+};

--- a/src/pages/tools/time/index.ts
+++ b/src/pages/tools/time/index.ts
@@ -9,6 +9,7 @@ import { tool as convertTimetoSeconds } from './convert-time-to-seconds/meta';
 import { tool as truncateClockTime } from './truncate-clock-time/meta';
 import { tool as checkLeapYear } from './check-leap-years/meta';
 import { tool as discordTimestamp } from './discord-timestamp/meta';
+import { tool as dateWeekdayCalculator } from './date-weekday-calculator/meta';
 
 export const timeTools = [
   daysDoHours,
@@ -21,5 +22,6 @@ export const timeTools = [
   checkLeapYear,
   timeConvertUnixToDate,
   timeConvertTimeToDecimal,
-  discordTimestamp
+  discordTimestamp,
+  dateWeekdayCalculator
 ];


### PR DESCRIPTION
## Summary

Adds a Date Weekday Calculator tool to the Time category.

### Features

- Select a month, day, weekday, and year range
- Automatically finds all matching years
- Supports leap day (February 29) by skipping non-leap years
- Live result updates
- Copyable formatted results

### Implementation

- Added a new tool under the Time category
- Localized labels, summaries, and validation messages
- Added comprehensive unit tests
- Integrated with the existing ToolContent workflow

### Tests

- Matching year calculation
- Leap year handling
- Invalid dates
- Invalid year ranges
- Boundary years
- Input parsing
- Result formatting

Closes #411