### PR TITLE
fix(sum): treat the advertised line-break delimiter as a real newline

### DIFF
--- a/src/pages/tools/number/sum/service.ts
+++ b/src/pages/tools/number/sum/service.ts
@@ -16,7 +16,10 @@ export const compute = (
   if (extractionType === 'smart') {
     numbers = getAllNumbers(input);
   } else {
-    const parts = input.split(separator);
+    // The UI advertises a literal "\n" option as a line break; normalize it to an actual newline
+    // so multiline inputs split correctly instead of being treated as a single part.
+    const normalizedSeparator = separator.replace(/\\n/g, '\n');
+    const parts = input.split(normalizedSeparator);
     // Filter out and convert parts that are numbers
     numbers = parts
       .filter((part) => !isNaN(Number(part)) && part.trim() !== '')

--- a/src/pages/tools/number/sum/sum.service.test.ts
+++ b/src/pages/tools/number/sum/sum.service.test.ts
@@ -61,4 +61,16 @@ describe('compute function', () => {
     const result = compute(input, 'delimiter', false, ';');
     expect(result).toBe('13');
   });
+
+  it('should treat a literal \\n separator as a real line break (multiline sum)', () => {
+    const input = '1\n2\n4';
+    const result = compute(input, 'delimiter', false, '\\n');
+    expect(result).toBe('7');
+  });
+
+  it('should return running sum with a literal \\n separator', () => {
+    const input = '1\n2\n4';
+    const result = compute(input, 'delimiter', true, '\\n');
+    expect(result).toBe('1\n3\n7\n');
+  });
 });


### PR DESCRIPTION
## Summary

Fixes the Sum tool's delimiter mode. It exposed a literal `\n` as the default line-break separator and shipped multiline examples using it, but passed those two literal characters straight into `String.split`. As a result, multiline input such as `1\n2` summed to `0` instead of `3`.

## Changes

- `service.ts`: normalize a literal `\n` separator into an actual newline before splitting, so multiline inputs are split correctly.
- `sum.service.test.ts`: added two unit tests covering the multiline sum and the running-sum output with the default separator.

## Tests

```
npx vitest run src/pages/tools/number/sum/sum.service.test.ts
```

12 tests passed (10 existing + 2 new).

Closes #416