### PR TITLE
fix(hooks): skip the effect on initial mount in useUpdateEffect

### DIFF
--- a/src/hooks/useUpdateEffect.test.ts
+++ b/src/hooks/useUpdateEffect.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it, vi } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import useUpdateEffect from './useUpdateEffect';
+
+describe('useUpdateEffect', () => {
+  it('does not run the effect on initial mount', () => {
+    const effect = vi.fn();
+    renderHook(() => useUpdateEffect(effect));
+    expect(effect).not.toHaveBeenCalled();
+  });
+
+  it('runs the effect on updates only', () => {
+    const effect = vi.fn();
+    const { rerender } = renderHook(({ n }) => useUpdateEffect(effect, [n]), {
+      initialProps: { n: 1 },
+    });
+    expect(effect).not.toHaveBeenCalled();
+
+    rerender({ n: 2 });
+    expect(effect).toHaveBeenCalledTimes(1);
+
+    rerender({ n: 3 });
+    expect(effect).toHaveBeenCalledTimes(2);
+  });
+
+  it('runs the previous cleanup before the next update effect', () => {
+    const cleanup = vi.fn();
+    const effect = vi.fn(() => cleanup);
+    const { rerender } = renderHook(({ n }) => useUpdateEffect(effect, [n]), {
+      initialProps: { n: 1 },
+    });
+
+    rerender({ n: 2 });
+    expect(effect).toHaveBeenCalledTimes(1);
+    expect(cleanup).not.toHaveBeenCalled();
+
+    rerender({ n: 3 });
+    expect(effect).toHaveBeenCalledTimes(2);
+    expect(cleanup).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/hooks/useUpdateEffect.ts
+++ b/src/hooks/useUpdateEffect.ts
@@ -11,6 +11,7 @@ const useUpdateEffect = (effect: EffectCallback, deps?: DependencyList) => {
   useEffect(() => {
     if (isInitialMount.current) {
       isInitialMount.current = false;
+      return;
     }
     return effect();
   }, deps);


### PR DESCRIPTION
## Summary

`useUpdateEffect` documented an update-only contract (JSDoc: "only runs on updates and not on initial mount") but still invoked `effect()` during the first post-mount flush — it only flipped `isInitialMount` to false without skipping the call.

## Changes

- `useUpdateEffect.ts`: return early on the initial mount so the effect runs only on subsequent updates.
- `useUpdateEffect.test.ts` (new): unit tests for mount (no run), updates (run), and cleanup ordering.

## Tests

```
npx vitest run src/hooks/useUpdateEffect.test.ts src/pages/tools/number/sum/sum.service.test.ts
```

15 tests passed (12 sum + 3 new hooks).

Closes #417