### PR TITLE
fix(result): make copy-to-clipboard work on non-secure contexts

### DIFF
--- a/src/components/result/ToolCodeResult.tsx
+++ b/src/components/result/ToolCodeResult.tsx
@@ -5,6 +5,7 @@ import InputHeader from '../InputHeader';
 import ResultFooter from './ResultFooter';
 import { useTranslation } from 'react-i18next';
 import Editor from '@monaco-editor/react';
+import { copyToClipboard } from '@utils/clipboard';
 import mime from 'mime';
 import {
   globalInputHeight,
@@ -29,8 +30,7 @@ export default function ToolCodeResult({
   const theme = useTheme();
 
   const handleCopy = () => {
-    navigator.clipboard
-      .writeText(value)
+    copyToClipboard(value)
       .then(() => showSnackBar(t('toolTextResult.copied'), 'success'))
       .catch((err) => {
         showSnackBar(t('toolTextResult.copyFailed', { error: err }), 'error');

--- a/src/components/result/ToolTextResult.tsx
+++ b/src/components/result/ToolTextResult.tsx
@@ -4,6 +4,7 @@ import { CustomSnackBarContext } from '../../contexts/CustomSnackBarContext';
 import InputHeader from '../InputHeader';
 import ResultFooter from './ResultFooter';
 import { replaceSpecialCharacters } from '@utils/string';
+import { copyToClipboard } from '@utils/clipboard';
 import mime from 'mime';
 import { globalInputHeight } from '../../config/uiConfig';
 import { useTranslation } from 'react-i18next';
@@ -24,8 +25,7 @@ export default function ToolTextResult({
   const { t } = useTranslation();
   const { showSnackBar } = useContext(CustomSnackBarContext);
   const handleCopy = () => {
-    navigator.clipboard
-      .writeText(value)
+    copyToClipboard(value)
       .then(() => showSnackBar(t('toolTextResult.copied'), 'success'))
       .catch((err) => {
         showSnackBar(t('toolTextResult.copyFailed', { error: err }), 'error');

--- a/src/utils/clipboard.test.ts
+++ b/src/utils/clipboard.test.ts
@@ -1,0 +1,79 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { copyToClipboard } from './clipboard';
+
+const text = '{"hello":"world"}';
+
+function mockClipboardApi(enabled: boolean, reject = false) {
+  const writeText = vi.fn(
+    () =>
+      new Promise<void>((resolve, rejectFn) => {
+        if (reject) {
+          rejectFn(new Error('permission denied'));
+        } else {
+          resolve();
+        }
+      })
+  );
+  Object.defineProperty(globalThis, 'navigator', {
+    value: enabled
+      ? { clipboard: { writeText } }
+      : { clipboard: undefined },
+    configurable: true,
+    writable: true,
+  });
+  Object.defineProperty(window, 'isSecureContext', {
+    value: true,
+    configurable: true,
+    writable: true,
+  });
+  return writeText;
+}
+
+function mockExecCommand(returnValue: boolean) {
+  const execCommand = vi.fn(() => returnValue);
+  Object.defineProperty(document, 'execCommand', {
+    value: execCommand,
+    configurable: true,
+    writable: true,
+  });
+  return execCommand;
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('copyToClipboard', () => {
+  it('uses the async Clipboard API when available', async () => {
+    const writeText = mockClipboardApi(true);
+    await copyToClipboard(text);
+    expect(writeText).toHaveBeenCalledWith(text);
+  });
+
+  it('falls back to execCommand when the Clipboard API is unavailable', async () => {
+    mockClipboardApi(false);
+    const execCommand = mockExecCommand(true);
+    const appendChild = vi.spyOn(document.body, 'appendChild');
+
+    await copyToClipboard(text);
+
+    expect(execCommand).toHaveBeenCalledWith('copy');
+    expect(appendChild).toHaveBeenCalledTimes(1);
+  });
+
+  it('falls back to execCommand when the Clipboard API rejects', async () => {
+    mockClipboardApi(true, true);
+    const execCommand = mockExecCommand(true);
+
+    await copyToClipboard(text);
+
+    expect(execCommand).toHaveBeenCalledWith('copy');
+  });
+
+  it('throws when the fallback execCommand returns false', async () => {
+    mockClipboardApi(false);
+    mockExecCommand(false);
+
+    await expect(copyToClipboard(text)).rejects.toThrow('copy');
+  });
+});

--- a/src/utils/clipboard.ts
+++ b/src/utils/clipboard.ts
@@ -1,0 +1,30 @@
+/**
+ * Copy text to the clipboard, falling back to a hidden-textarea + execCommand
+ * approach when the async Clipboard API is unavailable. This commonly happens
+ * on http:// (non-secure) hosts, e.g. self-hosted tools like Umbrel.
+ */
+export const copyToClipboard = async (text: string): Promise<void> => {
+  const clipboardApiAvailable = navigator.clipboard && window.isSecureContext;
+  if (clipboardApiAvailable) {
+    try {
+      await navigator.clipboard.writeText(text);
+      return;
+    } catch {
+      // Clipboard API can reject (e.g. missing permission); fall back below.
+    }
+  }
+
+  const textarea = document.createElement('textarea');
+  textarea.value = text;
+  textarea.setAttribute('readonly', '');
+  textarea.style.position = 'absolute';
+  textarea.style.left = '-9999px';
+  document.body.appendChild(textarea);
+  textarea.select();
+  textarea.setSelectionRange(0, text.length);
+  const ok = document.execCommand('copy');
+  document.body.removeChild(textarea);
+  if (!ok) {
+    throw new Error('Failed to copy using the fallback method');
+  }
+};


### PR DESCRIPTION
## Summary

The "Copy" button on result panels (used by Prettify JSON and other text/code results) silently did nothing on non-secure contexts. `navigator.clipboard.writeText` is only available on `https` or `localhost`; on plain `http` hosts (e.g. a self-hosted Umbrel box) `navigator.clipboard` is `undefined`, so the click threw an uncaught `TypeError` and no feedback was shown.

## Changes

- **`src/utils/clipboard.ts`** (new): `copyToClipboard(text)` — uses the async Clipboard API when available, otherwise falls back to a hidden `textarea` + `document.execCommand('copy')`, the classic non-secure-context workaround. Throws a clear error if the fallback also fails.
- **`ToolCodeResult.tsx` / `ToolTextResult.tsx`**: both result components now call `copyToClipboard`, so Prettify JSON and every text/code result tool copy correctly in both secure and non-secure contexts.

## Tests

```
npx vitest run src/utils/clipboard.test.ts
```

4 new unit tests cover: Clipboard API path, fallback when the API is unavailable, fallback when the API rejects, and error when `execCommand` fails. Full suite: 72 files / 660 tests passing.

Fixes #390