### PR TITLE
fix(csv): drop blank lines in rows-to-columns as documented

### DIFF
--- a/src/pages/tools/csv/csv-rows-to-columns/csv-rows-to-columns.service.test.ts
+++ b/src/pages/tools/csv/csv-rows-to-columns/csv-rows-to-columns.service.test.ts
@@ -58,4 +58,16 @@ describe('csvRowsToColumns', () => {
       'Variety,Arabica,Robusta,Liberica,Mocha\nOrigin,Ethiopia,Africa,Philippines,1x'
     );
   });
+
+  it('should remove blank lines', () => {
+    const input = 'a,b\n\n1,2\n\nx,y';
+    const result = csvRowsToColumns(input, false, '', '#');
+    expect(result).toBe('a,1,x\nb,2,y');
+  });
+
+  it('should remove lines that contain only whitespace', () => {
+    const input = 'a,b\n   \n1,2';
+    const result = csvRowsToColumns(input, false, '', '#');
+    expect(result).toBe('a,1\nb,2');
+  });
 });

--- a/src/pages/tools/csv/csv-rows-to-columns/service.ts
+++ b/src/pages/tools/csv/csv-rows-to-columns/service.ts
@@ -25,7 +25,9 @@ export function csvRowsToColumns(
     .split('\n')
     .map((row) => row.split(','))
     .filter(
-      (row) => row.length > 0 && !row[0].trim().startsWith(commentCharacter)
+      (row) =>
+        !(row.length === 1 && row[0].trim() === '') &&
+        !row[0].trim().startsWith(commentCharacter)
     );
   const columnCount = Math.max(...rows.map((row) => row.length));
   for (let i = 0; i < rows.length; i++) {


### PR DESCRIPTION
## Summary

The Rows-to-Columns CSV tool retains blank lines as empty output columns, contradicting its own docs and the embedded example ("empty lines are automatically removed").

An empty line `""` becomes `[""]` after splitting on commas, which passes the old `row.length > 0` filter.

## Changes

- `service.ts`: filter out rows that consist of a single empty field (a blank line). Legitimate rows with an empty first field (e.g. `,a`) are still kept.

## Tests

```
npx vitest run src/pages/tools/csv/csv-rows-to-columns/csv-rows-to-columns.service.test.ts
```

2 new tests (blank lines removed, whitespace-only lines removed). 11 tests passing.

Fixes #418