### PR TITLE
fix: support subpath deployment via BASE_URL

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,10 +11,13 @@ RUN npm run build
 FROM nginx:alpine
 
 COPY --from=build /app/dist /usr/share/nginx/html
+COPY nginx.conf.template /etc/nginx/templates/default.conf.template
+COPY docker/10-normalize-base-url.envsh /docker-entrypoint.d/10-normalize-base-url.envsh
+COPY docker/40-generate-index.sh /docker-entrypoint.d/40-generate-index.sh
 
-RUN sed -i 's/application\/javascript.*js;/application\/javascript                js mjs;/' /etc/nginx/mime.types
-
-RUN sed -i 's|index  index.html index.htm;|index  index.html index.htm;\n        try_files $uri $uri/ /index.html;|' /etc/nginx/conf.d/default.conf
+RUN mv /usr/share/nginx/html/index.html /usr/share/nginx/html/index.html.template \
+    && chmod +x /docker-entrypoint.d/10-normalize-base-url.envsh \
+    /docker-entrypoint.d/40-generate-index.sh
 
 EXPOSE 80
 

--- a/docker/10-normalize-base-url.envsh
+++ b/docker/10-normalize-base-url.envsh
@@ -1,0 +1,27 @@
+#!/bin/sh
+
+base_url="${BASE_URL:-/}"
+
+case "$base_url" in
+  /*) ;;
+  *) base_url="/$base_url" ;;
+esac
+
+case "$base_url" in
+  */) ;;
+  *) base_url="$base_url/" ;;
+esac
+
+if ! printf '%s\n' "$base_url" | grep -Eq '^/$|^/([A-Za-z0-9._~-]+/)+$'; then
+  echo "error: BASE_URL contains unsupported path characters" >&2
+  return 1
+fi
+
+export BASE_URL="$base_url"
+
+if [ "$BASE_URL" = "/" ]; then
+  export BASE_URL_PATTERN='a^(?<resource_path>.*)'
+else
+  escaped_base_url=$(printf '%s\n' "$BASE_URL" | sed 's/\./\\./g')
+  export BASE_URL_PATTERN="^${escaped_base_url}(?<resource_path>.*)$"
+fi

--- a/docker/40-generate-index.sh
+++ b/docker/40-generate-index.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -eu
+
+html_root=/usr/share/nginx/html
+
+envsubst '${BASE_URL}' \
+  < "$html_root/index.html.template" \
+  > "$html_root/index.html"

--- a/index.html
+++ b/index.html
@@ -1,19 +1,27 @@
 <!doctype html>
 <html lang="en">
-<head>
-  <meta charset="UTF-8" />
-  <link rel="icon" type="image/png" href="/favicon-96x96.png" sizes="96x96" />
-  <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-  <link rel="shortcut icon" href="/favicon.ico" />
-  <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
-  <meta name="apple-mobile-web-app-title" content="OmniTools" />
-  <link rel="manifest" href="/site.webmanifest" />
-  <link href="/assets/fonts/quicksand/quick-sand.css" rel="stylesheet" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>OmniTools</title>
-</head>
-<body>
-<div id="root"></div>
-<script type="module" src="/src/index.tsx"></script>
-</body>
+  <head>
+    <meta charset="UTF-8" />
+    <base href="/" data-runtime-base-url="__OMNI_TOOLS_BASE_URL__" />
+    <script>
+      const baseElement = document.querySelector('base');
+      const runtimeBaseUrl = baseElement.dataset.runtimeBaseUrl;
+      if (!runtimeBaseUrl.startsWith('$')) {
+        baseElement.href = runtimeBaseUrl;
+      }
+    </script>
+    <link rel="icon" type="image/png" href="favicon-96x96.png" sizes="96x96" />
+    <link rel="icon" type="image/svg+xml" href="favicon.svg" />
+    <link rel="shortcut icon" href="favicon.ico" />
+    <link rel="apple-touch-icon" sizes="180x180" href="apple-touch-icon.png" />
+    <meta name="apple-mobile-web-app-title" content="OmniTools" />
+    <link rel="manifest" href="site.webmanifest" />
+    <link href="assets/fonts/quicksand/quick-sand.css" rel="stylesheet" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>OmniTools</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="src/index.tsx"></script>
+  </body>
 </html>

--- a/nginx.conf.template
+++ b/nginx.conf.template
@@ -1,0 +1,22 @@
+server {
+    listen 80;
+    listen [::]:80;
+    server_name _;
+
+    root /usr/share/nginx/html;
+    index index.html;
+
+    include /etc/nginx/mime.types;
+    default_type application/octet-stream;
+
+    location ~* \.mjs$ {
+        rewrite ${BASE_URL_PATTERN} /$resource_path break;
+        try_files $uri =404;
+        default_type application/javascript;
+    }
+
+    location / {
+        rewrite ${BASE_URL_PATTERN} /$resource_path break;
+        try_files $uri $uri/ /index.html;
+    }
+}

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -25,6 +25,8 @@ const AppRoutes = () => {
 };
 
 function App() {
+  const basename =
+    new URL(document.baseURI).pathname.replace(/\/+$/, '') || '/';
   const [mode, setMode] = useState<Mode>(
     () => (localStorage.getItem('theme') || 'system') as Mode
   );
@@ -59,7 +61,7 @@ function App() {
         >
           <CustomSnackBarProvider>
             <UserTypeFilterProvider>
-              <BrowserRouter>
+              <BrowserRouter basename={basename}>
                 <Navbar
                   mode={mode}
                   onChangeMode={() => {

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -35,7 +35,8 @@ i18n
       escapeValue: false // react already safes from xss => https://www.i18next.com/translation-function/interpolation#unescape
     },
     backend: {
-      loadPath: '/locales/{{lng}}/{{ns}}.json'
+      loadPath:
+        new URL('locales/', document.baseURI).toString() + '{{lng}}/{{ns}}.json'
     },
     detection: {
       lookupLocalStorage: 'lang',

--- a/src/pages/home/index.tsx
+++ b/src/pages/home/index.tsx
@@ -8,6 +8,13 @@ import UserTypeFilter from '@components/UserTypeFilter';
 export default function Home() {
   const theme = useTheme();
   const { selectedUserTypes, setSelectedUserTypes } = useUserTypeFilter();
+  const backgroundUrl = new URL(
+    `assets/${
+      theme.palette.mode === 'dark' ? 'background-dark.png' : 'background.svg'
+    }`,
+    document.baseURI
+  ).toString();
+
   return (
     <Box
       padding={{
@@ -16,11 +23,7 @@ export default function Home() {
         lg: 5
       }}
       sx={{
-        background: `url(/assets/${
-          theme.palette.mode === 'dark'
-            ? 'background-dark.png'
-            : 'background.svg'
-        })`,
+        background: `url(${backgroundUrl})`,
         backgroundColor: 'background.default'
       }}
       display={'flex'}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,5 +1,5 @@
 /// <reference types="vitest" />
-import { defineConfig } from 'vite';
+import { defineConfig, Plugin } from 'vite';
 import react from '@vitejs/plugin-react-swc';
 import tsconfigPaths from 'vite-tsconfig-paths';
 import packageJson from './package.json';
@@ -7,9 +7,20 @@ import { execSync } from 'node:child_process';
 
 const commitHash = execSync('git rev-parse --short HEAD').toString().trim();
 
+const runtimeBaseUrlPlugin: Plugin = {
+  name: 'runtime-base-url',
+  transformIndexHtml(html, context) {
+    return html.replace(
+      '__OMNI_TOOLS_BASE_URL__',
+      context.server ? '/' : '$BASE_URL'
+    );
+  }
+};
+
 // https://vitejs.dev/config https://vitest.dev/config
 export default defineConfig({
-  plugins: [react(), tsconfigPaths()],
+  base: './',
+  plugins: [runtimeBaseUrlPlugin, react(), tsconfigPaths()],
   define: {
     'process.env': {},
     __APP_VERSION__: JSON.stringify(packageJson.version),


### PR DESCRIPTION
## Problem

OmniTools assumes it is deployed at the domain root, so assets, translations, React Router navigation, and nginx SPA fallbacks break when it is hosted under a subpath such as `/omni-tools/`.

## Solution

- emit relative Vite asset paths and configure `BrowserRouter` from the runtime document base
- resolve translation and homepage assets relative to that base
- replace Dockerfile `sed` patches with an nginx configuration template
- normalize `BASE_URL` at container startup and inject it into the built HTML with `envsubst`
- preserve root deployment behavior when `BASE_URL` is unset or `/`

## Validation

- `npm run build`
- `npm test -- --run` — 651 tests passed
- changed-file ESLint, Prettier, shell syntax, and `git diff --check`
- Docker deployment at `/` and with `BASE_URL=/omni-tools/`
- direct nested-route refresh through nginx
- JavaScript, CSS, translation, image, and `.mjs` assets under the subpath

Fixes #388
