### PR TITLE
fix: rename 'Import from file' button to 'Select files' for clarity

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -115,7 +115,7 @@
   "inputFooter": {
     "clear": "Clear",
     "copyToClipboard": "Copy to clipboard",
-    "importFromFile": "Import from file"
+    "importFromFile": "Select files"
   },
   "list": {
     "group": {

--- a/public/locales/en/video.json
+++ b/public/locales/en/video.json
@@ -111,7 +111,8 @@
       "resultTitle": "Animated GIF",
       "loadingText": "Creating GIF...",
       "frameOptions": "Frame Options",
-      "frameDelayDescription": "How long each frame is displayed, in milliseconds (e.g. 500 = 0.5 s per frame)"
+      "frameDelayDescription": "How long each frame is displayed, in milliseconds (e.g. 500 = 0.5 s per frame)",
+      "frameDelayMStoFPS": "Alternative way to set frame delay, in frames per second"
     }
   },
   "loop": {

--- a/src/components/input/ToolMultipleImageInput.tsx
+++ b/src/components/input/ToolMultipleImageInput.tsx
@@ -37,36 +37,7 @@ export default function ToolMultiImageInput({
     const files = event.target.files;
     if (!files) return;
 
-    const newFiles: MultiImageInput[] = await Promise.all(
-      Array.from(files).map(async (file, index) => {
-        let processedFile = file;
-
-        try {
-          if (await isHeic(file)) {
-            const convertedBlob = await heicTo({
-              blob: file,
-              type: 'image/jpeg'
-            });
-
-            processedFile = new File(
-              [convertedBlob],
-              file.name.replace(/\.[^/.]+$/, '') + '.jpg',
-              { type: 'image/jpeg' }
-            );
-          }
-        } catch (err) {
-          console.warn('HEIC conversion failed:', file.name, err);
-        }
-
-        return {
-          file: processedFile,
-          order: value.length + index,
-          preview: URL.createObjectURL(processedFile)
-        };
-      })
-    );
-
-    onChange([...value, ...newFiles]);
+    await processFiles(Array.from(files));
 
     event.target.value = '';
   };
@@ -99,6 +70,44 @@ export default function ToolMultiImageInput({
       : fileName;
   }
 
+  const processFiles = async (files: File[]) => {
+    const newFiles: MultiImageInput[] = await Promise.all(
+      Array.from(files).map(async (file, index) => {
+        let processedFile = file;
+
+        try {
+          if (await isHeic(file)) {
+            const convertedBlob = await heicTo({
+              blob: file,
+              type: 'image/jpeg'
+            });
+            processedFile = new File(
+              [convertedBlob],
+              file.name.replace(/\.[^/.]+$/, '') + '.jpg',
+              { type: 'image/jpeg' }
+            );
+          }
+        } catch (err) {
+          console.warn('HEIC conversion failed:', file.name, err);
+        }
+
+        return {
+          file: processedFile,
+          order: value.length + index,
+          preview: URL.createObjectURL(processedFile)
+        };
+      })
+    );
+
+    onChange([...value, ...newFiles]);
+  };
+
+  const handleDrop = (e: React.DragEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    const files = e.dataTransfer.files;
+    processFiles(Array.from(files));
+  };
+
   return (
     <Box>
       <InputHeader
@@ -119,6 +128,8 @@ export default function ToolMultiImageInput({
           bgcolor: 'background.paper',
           position: 'relative'
         }}
+        onDragOver={(e: React.DragEvent<HTMLDivElement>) => e.preventDefault()}
+        onDrop={handleDrop}
       >
         <Box
           width="100%"

--- a/src/pages/tools/video/gif/images-to-gif/index.tsx
+++ b/src/pages/tools/video/gif/images-to-gif/index.tsx
@@ -28,6 +28,7 @@ export default function ImagesToGif({ title }: ToolComponentProps) {
     input: MultiImageInput[]
   ) => {
     if (!input || input.length === 0) return;
+    setLoading(true);
     try {
       const convertedGif = await imagesToGif(
         input.map((item) => item.file),

--- a/src/pages/tools/video/gif/images-to-gif/index.tsx
+++ b/src/pages/tools/video/gif/images-to-gif/index.tsx
@@ -71,22 +71,39 @@ export default function ImagesToGif({ title }: ToolComponentProps) {
         {
           title: t('gif.imagesToGif.frameOptions'),
           component: (
-            <Box>
-              <TextFieldWithDesc
-                name="frameDelay"
-                type="number"
-                inputProps={{ min: 50, max: 10000, step: 50 }}
-                description={t('gif.imagesToGif.frameDelayDescription')}
-                onOwnChange={(value) => {
-                  const clamped = Math.min(
-                    10000,
-                    Math.max(50, Number(value))
-                  ).toString();
-                  updateNumberField(clamped, 'frameDelay', updateField);
-                }}
-                value={values.frameDelay}
-              />
-            </Box>
+            <>
+              <Box>
+                <TextFieldWithDesc
+                  name="frameDelay"
+                  type="number"
+                  inputProps={{ min: 50, max: 10000, step: 50 }}
+                  description={t('gif.imagesToGif.frameDelayDescription')}
+                  onOwnChange={(value) => {
+                    const clamped = Math.min(
+                      10000,
+                      Math.max(50, Number(value))
+                    ).toString();
+                    updateNumberField(clamped, 'frameDelay', updateField);
+                  }}
+                  value={values.frameDelay}
+                />
+              </Box>
+              <Box>
+                <TextFieldWithDesc
+                  name="frameDelayInFPS"
+                  type="number"
+                  inputProps={{ min: 1, max: 60 }}
+                  description={t('gif.imagesToGif.frameDelayMStoFPS')}
+                  onOwnChange={(value) => {
+                    const fps = Math.min(60, Math.max(1, Number(value)));
+                    const ms = 1000 / fps;
+                    const msString = ms.toString();
+                    updateNumberField(msString, 'frameDelay', updateField);
+                  }}
+                  value={1000 / values.frameDelay}
+                />
+              </Box>
+            </>
           )
         }
       ]}


### PR DESCRIPTION
Renames the "import from file" button to "Select files" for clarity.
Adds a loading indicator while GIF is loading.
Adds an FPS input as an alternative to setting frame delay in milliseconds
Adds the drag and drop features

#433