### PR TITLE
fix(README): restore star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ npm run test:e2e
 ### i18n (Translations)
 The translation files are [here](public/locales). Only edit these if you are a developer. For non developers, use [Locize](https://www.locize.app/register?invitation=YOIH0Dyz3KHh3uQFCGYe9v1QOUoq8W5ySgmlwjX9cSypeJmt8F40brDtVbXb71fK).
 
- <!--<img src="https://api.star-history.com/svg?repos=iib0011/omni-tools&type=Date"/> -->
+<img src="https://star-history.dera.page/svg?repos=iib0011/omni-tools&type=Date"/>
 
 ## 🤝 Looking to contribute?
 

--- a/README.md
+++ b/README.md
@@ -151,6 +151,8 @@ npm run test:e2e
 ### i18n (Translations)
 The translation files are [here](public/locales). Only edit these if you are a developer. For non developers, use [Locize](https://www.locize.app/register?invitation=YOIH0Dyz3KHh3uQFCGYe9v1QOUoq8W5ySgmlwjX9cSypeJmt8F40brDtVbXb71fK).
 
+## ⭐ Star History
+
 <img src="https://star-history.dera.page/svg?repos=iib0011/omni-tools&type=Date"/>
 
 ## 🤝 Looking to contribute?


### PR DESCRIPTION
The star history chart in the README is broken and no longer displays. This MR restores it, referencing the commit that removed it (14629f3), so the project's stargazer history is visible again.