### PR TITLE
fix(xml): preserve attributes when beautifying XML

### DIFF
--- a/src/pages/tools/xml/xml-beautifier/service.ts
+++ b/src/pages/tools/xml/xml-beautifier/service.ts
@@ -13,9 +13,13 @@ export function beautifyXml(
     return 'Invalid XML';
   }
   try {
-    const parser = new XMLParser();
+    const parser = new XMLParser({ ignoreAttributes: false });
     const obj = parser.parse(input);
-    const builder = new XMLBuilder({ format: true, indentBy: '  ' });
+    const builder = new XMLBuilder({
+      format: true,
+      indentBy: '  ',
+      ignoreAttributes: false
+    });
     return builder.build(obj);
   } catch (e: any) {
     return `Invalid XML: ${e.message}`;

--- a/src/pages/tools/xml/xml-beautifier/xml-beautifier.service.test.ts
+++ b/src/pages/tools/xml/xml-beautifier/xml-beautifier.service.test.ts
@@ -10,6 +10,13 @@ describe('xml-beautifier', () => {
     expect(result).toContain('  <b>2</b>');
   });
 
+  it('preserves attributes while beautifying XML', () => {
+    const input = '<root><user id="42" role="admin">Alice</user></root>';
+    const result = beautifyXml(input, {});
+
+    expect(result).toContain('<user id="42" role="admin">Alice</user>');
+  });
+
   it('returns error for invalid XML', () => {
     const input = '<root><a>1</b></root>';
     const result = beautifyXml(input, {});


### PR DESCRIPTION
## Summary
- Configure the XML parser to retain attributes.
- Configure the XML builder to serialize retained attributes.
- Add regression coverage for an element with multiple attributes.

## Problem
XML Beautifier used fast-xml-parser defaults, which ignore attributes. Formatting input such as a user element with id and role attributes silently removed both attributes from the output, changing the document instead of only formatting it.

## Testing
- npx vitest run src/pages/tools/xml/xml-beautifier/xml-beautifier.service.test.ts
- npm run typecheck