### PR TITLE
fix(list): compare full strings in case-sensitive sort

### DIFF
--- a/src/pages/tools/list/sort/service.ts
+++ b/src/pages/tools/list/sort/service.ts
@@ -60,7 +60,7 @@ function customAlphabeticSort(
     return a.toLowerCase().localeCompare(b.toLowerCase());
   } else {
     // Case-sensitive comparison
-    return a.charCodeAt(0) - b.charCodeAt(0);
+    return a === b ? 0 : a < b ? -1 : 1;
   }
 }
 

--- a/src/pages/tools/list/sort/sort.service.test.ts
+++ b/src/pages/tools/list/sort/sort.service.test.ts
@@ -183,6 +183,12 @@ describe('numericSort function', () => {
     });
 
     // CASE SENSITIVE TEST
+    it('should compare the full string when prefixes match', () => {
+      const result = alphabeticSort(['az', 'aa'], true, ',', false, true);
+
+      expect(result).toBe('aa,az');
+    });
+
     it('should sort a list of string (uppercase) in decreasing order with comma separator ', () => {
       const array: string[] = ['Apple', 'Pineaple', 'Lemon', 'Orange'];
       const increasing: boolean = false;


### PR DESCRIPTION
## Summary
- Compare complete strings in case-sensitive alphabetical mode.
- Preserve code-unit ordering, including uppercase before lowercase.
- Add regression coverage for values that share their first character.

## Problem
The case-sensitive comparator only compared charCodeAt(0). Values such as az and aa therefore compared equal and retained input order, producing az,aa instead of aa,az.

## Testing
- npx vitest run src/pages/tools/list/sort/sort.service.test.ts
- npm run typecheck