### PR TITLE
fix(image): preserve EXIF metadata during compression

### DIFF
--- a/src/pages/tools/image/generic/compress/compress.service.test.ts
+++ b/src/pages/tools/image/generic/compress/compress.service.test.ts
@@ -1,0 +1,28 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import imageCompression from 'browser-image-compression';
+import { compressImages } from './service';
+
+vi.mock('browser-image-compression', () => ({
+  default: vi.fn()
+}));
+
+describe('compressImages', () => {
+  beforeEach(() => {
+    vi.mocked(imageCompression).mockResolvedValue(
+      new File(['compressed'], 'photo.jpg', { type: 'image/jpeg' })
+    );
+  });
+
+  it('preserves JPEG EXIF metadata while compressing', async () => {
+    const input = new File(['original'], 'photo.jpg', {
+      type: 'image/jpeg'
+    });
+
+    await compressImages([input], { maxFileSizeInMB: 1, quality: 80 });
+
+    expect(imageCompression).toHaveBeenCalledWith(
+      input,
+      expect.objectContaining({ preserveExif: true })
+    );
+  });
+});

--- a/src/pages/tools/image/generic/compress/service.ts
+++ b/src/pages/tools/image/generic/compress/service.ts
@@ -14,6 +14,7 @@ export const compressImages = async (
       maxSizeMB: maxFileSizeInMB,
       maxWidthOrHeight: 1920, // Reasonable default for most use cases
       useWebWorker: true,
+      preserveExif: true,
       initialQuality: quality / 100 // Convert percentage to decimal
     };
 


### PR DESCRIPTION
## Summary

- preserve JPEG EXIF metadata when using the generic image compressor
- add a regression test that verifies compression enables the library's metadata-preservation option

## Why

The compression dependency strips EXIF data by default unless `preserveExif` is explicitly enabled. This caused camera model, focal length, and similar metadata to disappear from compressed JPEGs.

## Testing

- `npx vitest run src/pages/tools/image/generic/compress/compress.service.test.ts`
- `npm run typecheck`

Fixes #395