### PR TITLE
fix(docker): let nginx initialize its IPv6 listener

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+docker/*.sh text eol=lf

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,8 @@ COPY --from=build /app/dist /usr/share/nginx/html
 
 RUN sed -i 's/application\/javascript.*js;/application\/javascript                js mjs;/' /etc/nginx/mime.types
 
-RUN sed -i 's|index  index.html index.htm;|index  index.html index.htm;\n        try_files $uri $uri/ /index.html;|' /etc/nginx/conf.d/default.conf
+COPY docker/40-enable-spa-routing.sh /docker-entrypoint.d/
+RUN chmod +x /docker-entrypoint.d/40-enable-spa-routing.sh
 
 EXPOSE 80
 

--- a/docker/40-enable-spa-routing.sh
+++ b/docker/40-enable-spa-routing.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -eu
+
+config=/etc/nginx/conf.d/default.conf
+
+if ! grep -Fq 'try_files $uri $uri/ /index.html;' "$config"; then
+  sed -i 's|index  index.html index.htm;|index  index.html index.htm;\n        try_files $uri $uri/ /index.html;|' "$config"
+fi


### PR DESCRIPTION
## Summary

- defer the SPA `try_files` patch to an nginx entrypoint script
- run the patch after nginx's built-in IPv6 initialization
- keep the SPA patch idempotent across container restarts
- enforce LF endings for the entrypoint shell script

## Why

The Dockerfile previously changed `/etc/nginx/conf.d/default.conf` while building the image. The nginx image's `10-listen-on-ipv6-by-default.sh` detects that early modification and exits without adding `listen [::]:80`, leaving the container IPv4-only.

The new `40-enable-spa-routing.sh` runs after nginx's IPv6 initializer, preserving both IPv6 listening and SPA fallback routing.

## Testing

- `sh -n docker/40-enable-spa-routing.sh`
- `git diff --check`

A container runtime is not installed in the local environment, so I could not execute an image-level smoke test.

Fixes #264