### PR TITLE
fix: skip useUpdateEffect callback on initial mount

### DIFF
--- a/src/hooks/useUpdateEffect.test.ts
+++ b/src/hooks/useUpdateEffect.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it, vi } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import useUpdateEffect from './useUpdateEffect';
+
+describe('useUpdateEffect', () => {
+  it('does not invoke the effect on initial mount', () => {
+    const effect = vi.fn();
+    renderHook(() => useUpdateEffect(effect, []));
+    expect(effect).not.toHaveBeenCalled();
+  });
+
+  it('invokes the effect when dependencies update', () => {
+    const effect = vi.fn();
+    const { rerender } = renderHook(
+      ({ dep }) => useUpdateEffect(effect, [dep]),
+      { initialProps: { dep: 0 } }
+    );
+    rerender({ dep: 1 });
+    expect(effect).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/hooks/useUpdateEffect.ts
+++ b/src/hooks/useUpdateEffect.ts
@@ -11,6 +11,7 @@ const useUpdateEffect = (effect: EffectCallback, deps?: DependencyList) => {
   useEffect(() => {
     if (isInitialMount.current) {
       isInitialMount.current = false;
+      return;
     }
     return effect();
   }, deps);


### PR DESCRIPTION
## Summary
Fixes #417

The exported \useUpdateEffect\ hook invoked its callback during the first post-mount effect flush, contradicting its documented update-only contract. The initial-mount branch reset the ref but fell through to \eturn effect()\.

## Changes
- Return early on the initial mount so the effect only runs on dependency updates (\src/hooks/useUpdateEffect.ts\)
- Add regression tests asserting 0 invocations on mount and exactly 1 after a dependency change (\src/hooks/useUpdateEffect.test.ts\)

## Testing
- \
px vitest run src/hooks/useUpdateEffect.test.ts\ — 2 passed
- Full typecheck passes; the two pre-existing \eact-hooks/exhaustive-deps\ warnings are unchanged from main