### PR TITLE
fix: treat literal \n separator as line break in Number Sum

### DIFF
--- a/src/pages/tools/number/sum/service.ts
+++ b/src/pages/tools/number/sum/service.ts
@@ -16,7 +16,8 @@ export const compute = (
   if (extractionType === 'smart') {
     numbers = getAllNumbers(input);
   } else {
-    const parts = input.split(separator);
+    const normalizedSeparator = separator.replace(/\\n/g, '\n');
+    const parts = input.split(normalizedSeparator);
     // Filter out and convert parts that are numbers
     numbers = parts
       .filter((part) => !isNaN(Number(part)) && part.trim() !== '')

--- a/src/pages/tools/number/sum/sum.service.test.ts
+++ b/src/pages/tools/number/sum/sum.service.test.ts
@@ -61,4 +61,16 @@ describe('compute function', () => {
     const result = compute(input, 'delimiter', false, ';');
     expect(result).toBe('13');
   });
+
+  it('should treat the literal \\n separator as a line break', () => {
+    const input = '1\n2';
+    const result = compute(input, 'delimiter', false, '\\n');
+    expect(result).toBe('3');
+  });
+
+  it('should still sum with an actual newline separator', () => {
+    const input = '1\n2';
+    const result = compute(input, 'delimiter', false, '\n');
+    expect(result).toBe('3');
+  });
 });


### PR DESCRIPTION
## Summary
Fixes #416

The Sum tool's delimiter mode advertises a line-break default and its examples pass the two-character option value \\\\\n\, but \compute\ split on those literal characters unchanged. The shipped example returned 0 instead of 19494, and input like \1\\n2\ returned 0 instead of 3.

## Changes
- Normalize the separator with \separator.replace(/\\\\n/g, '\\n')\ before splitting (\src/pages/tools/number/sum/service.ts\)
- Add regression tests for both the literal \\n\ option and an actual newline separator (\sum.service.test.ts\)

## Testing
- \
px vitest run src/pages/tools/number/sum/sum.service.test.ts\ — 12 passed (10 existing + 2 new)
- Full typecheck passes