### PR TITLE
fix: remove blank lines before CSV rows-to-columns transposition

### DIFF
--- a/src/pages/tools/csv/csv-rows-to-columns/csv-rows-to-columns.service.test.ts
+++ b/src/pages/tools/csv/csv-rows-to-columns/csv-rows-to-columns.service.test.ts
@@ -58,4 +58,10 @@ describe('csvRowsToColumns', () => {
       'Variety,Arabica,Robusta,Liberica,Mocha\nOrigin,Ethiopia,Africa,Philippines,1x'
     );
   });
+
+  it('should remove blank lines before transposing', () => {
+    const input = 'a,b\n\nc,d';
+    const result = csvRowsToColumns(input, false, '', '#');
+    expect(result).toBe('a,c\nb,d');
+  });
 });

--- a/src/pages/tools/csv/csv-rows-to-columns/service.ts
+++ b/src/pages/tools/csv/csv-rows-to-columns/service.ts
@@ -25,7 +25,9 @@ export function csvRowsToColumns(
     .split('\n')
     .map((row) => row.split(','))
     .filter(
-      (row) => row.length > 0 && !row[0].trim().startsWith(commentCharacter)
+      (row) =>
+        row.some((cell) => cell.trim() !== '') &&
+        !row[0].trim().startsWith(commentCharacter)
     );
   const columnCount = Math.max(...rows.map((row) => row.length));
   for (let i = 0; i < rows.length; i++) {


### PR DESCRIPTION
Fixes #418

## Summary

CSV Rows-to-Columns retained blank input lines as empty records, producing phantom empty columns in the transposed output. This contradicted the tool's own documentation and embedded example, both of which say blank lines are cleaned before conversion.

## Root cause

A blank input line splits into `['']`, whose length passes the old `row.length > 0` filter, so it survived as a record of one empty cell.

## Changes

- Filter out records where every cell is blank before transposition (`src/pages/tools/csv/csv-rows-to-columns/service.ts`)
- Regression test for `a,b\n\nc,d` -> `a,c\nb,d` (previously returned `a,,c\nb,,d`)

## Testing

- `npx vitest run src/pages/tools/csv/csv-rows-to-columns/` - 10 passed
- Typecheck and lint clean
