### PR TITLE
fix: make copy-to-clipboard work on insecure (HTTP) origins

### DIFF
--- a/src/components/input/ToolCodeInput.tsx
+++ b/src/components/input/ToolCodeInput.tsx
@@ -1,6 +1,7 @@
 import { Box, useTheme } from '@mui/material';
 import React, { useContext, useRef } from 'react';
 import { CustomSnackBarContext } from '../../contexts/CustomSnackBarContext';
+import { copyToClipboard } from '../../utils/clipboard';
 import InputHeader from '../InputHeader';
 import InputFooter from './InputFooter';
 import { useTranslation } from 'react-i18next';
@@ -27,8 +28,7 @@ export default function ToolCodeInput({
   const theme = useTheme();
 
   const handleCopy = () => {
-    navigator.clipboard
-      .writeText(value)
+    copyToClipboard(value)
       .then(() => showSnackBar(t('toolTextInput.copied'), 'success'))
       .catch((err) => {
         showSnackBar(t('toolTextInput.copyFailed', { error: err }), 'error');

--- a/src/components/input/ToolTextInput.tsx
+++ b/src/components/input/ToolTextInput.tsx
@@ -1,6 +1,7 @@
 import { Box, TextField } from '@mui/material';
 import React, { useContext, useRef } from 'react';
 import { CustomSnackBarContext } from '../../contexts/CustomSnackBarContext';
+import { copyToClipboard } from '../../utils/clipboard';
 import InputHeader from '../InputHeader';
 import InputFooter from './InputFooter';
 import { useTranslation } from 'react-i18next';
@@ -21,8 +22,7 @@ export default function ToolTextInput({
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   const handleCopy = () => {
-    navigator.clipboard
-      .writeText(value)
+    copyToClipboard(value)
       .then(() => showSnackBar(t('toolTextInput.copied'), 'success'))
       .catch((err) => {
         showSnackBar(t('toolTextInput.copyFailed', { error: err }), 'error');

--- a/src/components/result/ToolCodeResult.tsx
+++ b/src/components/result/ToolCodeResult.tsx
@@ -1,6 +1,7 @@
 import { Box, CircularProgress, Typography, useTheme } from '@mui/material';
 import React, { useContext } from 'react';
 import { CustomSnackBarContext } from '../../contexts/CustomSnackBarContext';
+import { copyToClipboard } from '../../utils/clipboard';
 import InputHeader from '../InputHeader';
 import ResultFooter from './ResultFooter';
 import { useTranslation } from 'react-i18next';
@@ -29,8 +30,7 @@ export default function ToolCodeResult({
   const theme = useTheme();
 
   const handleCopy = () => {
-    navigator.clipboard
-      .writeText(value)
+    copyToClipboard(value)
       .then(() => showSnackBar(t('toolTextResult.copied'), 'success'))
       .catch((err) => {
         showSnackBar(t('toolTextResult.copyFailed', { error: err }), 'error');

--- a/src/components/result/ToolDiffResult.tsx
+++ b/src/components/result/ToolDiffResult.tsx
@@ -3,6 +3,7 @@ import InputHeader from '../InputHeader';
 import ResultFooter from './ResultFooter';
 import { useContext } from 'react';
 import { CustomSnackBarContext } from '../../contexts/CustomSnackBarContext';
+import { copyToClipboard } from '../../utils/clipboard';
 import { globalInputHeight } from '../../config/uiConfig';
 import { useTranslation } from 'react-i18next';
 import { stripAndDecodeHtml } from 'utils/string';
@@ -30,8 +31,7 @@ export default function ToolDiffResult({
 
   const handleCopy = () => {
     const text = isHtml ? stripAndDecodeHtml(value) : value;
-    navigator.clipboard
-      .writeText(text)
+    copyToClipboard(text)
       .then(() => showSnackBar(t('toolTextResult.copied'), 'success'))
       .catch((err) =>
         showSnackBar(t('toolTextResult.copyFailed', { error: err }), 'error')

--- a/src/components/result/ToolTextResult.tsx
+++ b/src/components/result/ToolTextResult.tsx
@@ -1,6 +1,7 @@
 import { Box, CircularProgress, TextField, Typography } from '@mui/material';
 import React, { useContext } from 'react';
 import { CustomSnackBarContext } from '../../contexts/CustomSnackBarContext';
+import { copyToClipboard } from '../../utils/clipboard';
 import InputHeader from '../InputHeader';
 import ResultFooter from './ResultFooter';
 import { replaceSpecialCharacters } from '@utils/string';
@@ -24,8 +25,7 @@ export default function ToolTextResult({
   const { t } = useTranslation();
   const { showSnackBar } = useContext(CustomSnackBarContext);
   const handleCopy = () => {
-    navigator.clipboard
-      .writeText(value)
+    copyToClipboard(value)
       .then(() => showSnackBar(t('toolTextResult.copied'), 'success'))
       .catch((err) => {
         showSnackBar(t('toolTextResult.copyFailed', { error: err }), 'error');

--- a/src/utils/clipboard.ts
+++ b/src/utils/clipboard.ts
@@ -1,0 +1,22 @@
+export const copyToClipboard = async (text: string): Promise<void> => {
+  if (navigator.clipboard && window.isSecureContext) {
+    await navigator.clipboard.writeText(text);
+    return;
+  }
+  // Fallback for insecure contexts (e.g. self-hosted instances served over
+  // plain HTTP), where navigator.clipboard is unavailable.
+  const textarea = document.createElement('textarea');
+  textarea.value = text;
+  textarea.style.position = 'fixed';
+  textarea.style.opacity = '0';
+  document.body.appendChild(textarea);
+  textarea.focus();
+  textarea.select();
+  try {
+    if (!document.execCommand('copy')) {
+      throw new Error('Copy command failed');
+    }
+  } finally {
+    document.body.removeChild(textarea);
+  }
+};


### PR DESCRIPTION
Fixes #390

## Summary

Copy to clipboard silently failed on self-hosted instances served over plain HTTP (e.g. Umbrel, LAN deployments): `navigator.clipboard` is only available in secure contexts, so the call threw with no fallback.

## Root cause

Five input/result components duplicated the same `navigator.clipboard.writeText(...)` logic with no insecure-context fallback and no guard for the API being undefined.

## Changes

- Add a shared `copyToClipboard` util (`src/utils/clipboard.ts`) that uses the async Clipboard API when available and falls back to a hidden-textarea + `document.execCommand('copy')` otherwise
- Replace the duplicated clipboard logic in all five components (`ToolTextInput`, `ToolCodeInput`, `ToolTextResult`, `ToolCodeResult`, `ToolDiffResult`); snackbar success/error behavior is unchanged

## Testing

- Typecheck clean, eslint clean on all touched files
- Manual: copy button now works on HTTP origins via the execCommand path; HTTPS behavior unchanged
