### PR TITLE
fix: return the requested number of string chunks

### DIFF
--- a/src/pages/tools/string/split/service.ts
+++ b/src/pages/tools/string/split/service.ts
@@ -18,17 +18,15 @@ function splitIntoChunks(text: string, numChunks: number) {
       'Text length must be at least as long as the number of chunks'
     );
 
-  const chunkSize = Math.ceil(totalLength / numChunks); // Calculate the chunk size, rounding up to handle remainders
-  let result = [];
+  const chunkSize = Math.floor(totalLength / numChunks);
+  const remainder = totalLength % numChunks;
+  const result: string[] = [];
+  let offset = 0;
 
-  for (let i = 0; i < totalLength; i += chunkSize) {
-    result.push(text.slice(i, i + chunkSize));
-  }
-
-  // Ensure the result contains exactly numChunks, adjusting the last chunk if necessary
-  if (result.length > numChunks) {
-    result[numChunks - 1] = result.slice(numChunks - 1).join(''); // Merge any extra chunks into the last chunk
-    result = result.slice(0, numChunks); // Take only the first numChunks chunks
+  for (let i = 0; i < numChunks; i++) {
+    const currentSize = chunkSize + (i < remainder ? 1 : 0);
+    result.push(text.slice(offset, offset + currentSize));
+    offset += currentSize;
   }
 
   return result;

--- a/src/pages/tools/string/split/string-split.service.test.ts
+++ b/src/pages/tools/string/split/string-split.service.test.ts
@@ -42,6 +42,11 @@ describe('compute function', () => {
     expect(result).toBe('[hello],[world],[again]');
   });
 
+  it('should return the requested number of uneven chunks', () => {
+    const result = compute('chunks', 'abcdef', '', '', 0, 4, '[', ']', ',');
+    expect(result).toBe('[ab],[cd],[e],[f]');
+  });
+
   it('should handle empty input', () => {
     const result = compute('symbol', '', ' ', '', 0, 0, '', '', ',');
     expect(result).toBe('');


### PR DESCRIPTION
## Problem

The String Split tool uses a rounded-up fixed chunk size. For uneven divisions this can produce fewer chunks than requested; for example, splitting six characters into four chunks returns only three.

## Changes

- distribute remainder characters across the first chunks
- always return exactly the requested chunk count when the input is long enough
- add a regression test for a six-character, four-chunk split

## Verification

- `npx vitest run src/pages/tools/string/split/string-split.service.test.ts`
- `npm run typecheck`
